### PR TITLE
feat: add manual approval requirement for npm publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,6 +15,9 @@ jobs:
   release:
     name: Release @fearlessfara/apigw-vtl-emulator
     runs-on: ubuntu-latest
+    environment:
+      name: npm-production
+      url: https://www.npmjs.com/package/@fearlessfara/apigw-vtl-emulator
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
Added GitHub Environment 'npm-production' to publish workflow to require manual approval before publishing to npmjs. This ensures releases are reviewed before being made public.

To enable approval:
1. Go to Settings > Environments in GitHub
2. Create environment: npm-production
3. Add required reviewers
4. Configure NPM_TOKEN secret for the environment