### PR TITLE
fix: improve semantic-release branch handling

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -50,7 +50,21 @@ jobs:
         working-directory: emulator/typescript
         run: npm run build
 
+      - name: Check branch
+        id: check-branch
+        run: |
+          BRANCH=${GITHUB_REF#refs/heads/}
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          if [[ "$BRANCH" != "main" && "$BRANCH" != "master" ]]; then
+            echo "⚠️  Skipping release - not on main/master branch (current: $BRANCH)"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "✅ On release branch: $BRANCH"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run semantic-release
+        if: steps.check-branch.outputs.skip != 'true'
         working-directory: emulator/typescript
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/emulator/typescript/.releaserc.json
+++ b/emulator/typescript/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main"],
+  "branches": ["main", "master"],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
- Support both 'main' and 'master' branch names in semantic-release config
- Add explicit branch check in workflow to prevent failures on feature branches
- Skip semantic-release step if not on main/master branch

This fixes the ERELEASEBRANCHES error when running in repositories without a main branch yet or when workflow is manually triggered on feature branches.