### PR TITLE
fix: change package name to apigw-vtl-emulator (public package)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -13,11 +13,11 @@ on:
 
 jobs:
   release:
-    name: Release @fearlessfara/apigw-vtl-emulator
+    name: Release apigw-vtl-emulator
     runs-on: ubuntu-latest
     environment:
       name: npm-production
-      url: https://www.npmjs.com/package/@fearlessfara/apigw-vtl-emulator
+      url: https://www.npmjs.com/package/apigw-vtl-emulator
     permissions:
       contents: write
       issues: write

--- a/emulator/typescript/README.md
+++ b/emulator/typescript/README.md
@@ -1,10 +1,10 @@
-# @fearlessfara/apigw-vtl-emulator
+# apigw-vtl-emulator
 
 > TypeScript/JavaScript implementation of AWS API Gateway VTL (Velocity Template Language) Emulator
 
 A complete, fully-tested implementation of AWS API Gateway's VTL processor that works in both Node.js and browser environments. Built on top of [`@fearlessfara/velocits`](https://github.com/fearlessfara/velocits), a TypeScript port of Apache Velocity.
 
-[![npm version](https://badge.fury.io/js/@fearlessfara%2Fapigw-vtl-emulator.svg)](https://www.npmjs.com/package/@fearlessfara/apigw-vtl-emulator)
+[![npm version](https://badge.fury.io/js/apigw-vtl-emulator.svg)](https://www.npmjs.com/package/apigw-vtl-emulator)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Features
@@ -29,7 +29,7 @@ A complete, fully-tested implementation of AWS API Gateway's VTL processor that 
 ## Installation
 
 ```bash
-npm install @fearlessfara/apigw-vtl-emulator
+npm install apigw-vtl-emulator
 ```
 
 ## Quick Start
@@ -37,7 +37,7 @@ npm install @fearlessfara/apigw-vtl-emulator
 ### Basic Usage
 
 ```typescript
-import { VTLProcessor } from '@fearlessfara/apigw-vtl-emulator';
+import { VTLProcessor } from 'apigw-vtl-emulator';
 
 const processor = new VTLProcessor();
 
@@ -71,7 +71,7 @@ console.log(result);
 ### Node.js Example
 
 ```javascript
-const { VTLProcessor } = require('@fearlessfara/apigw-vtl-emulator');
+const { VTLProcessor } = require('apigw-vtl-emulator');
 
 const processor = new VTLProcessor();
 const result = processor.process(
@@ -85,7 +85,7 @@ console.log(result); // {"name":"John"}
 ### Browser Example (React)
 
 ```tsx
-import { VTLProcessor } from '@fearlessfara/apigw-vtl-emulator';
+import { VTLProcessor } from 'apigw-vtl-emulator';
 import { useState } from 'react';
 
 function VTLEditor() {
@@ -244,7 +244,7 @@ import {
   InputFunctions,
   ContextFunctions,
   UtilFunctions
-} from '@fearlessfara/apigw-vtl-emulator';
+} from 'apigw-vtl-emulator';
 
 const processor: VTLProcessor = new VTLProcessor();
 ```

--- a/emulator/typescript/package.json
+++ b/emulator/typescript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fearlessfara/apigw-vtl-emulator",
+  "name": "apigw-vtl-emulator",
   "version": "1.1.0",
   "description": "TypeScript/JavaScript implementation of AWS API Gateway VTL Emulator - works in Node.js and browsers",
   "type": "module",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "@fearlessfara/apigw-vtl-emulator": "file:../emulator/typescript",
+    "apigw-vtl-emulator": "file:../emulator/typescript",
     "@monaco-editor/react": "^4.7.0",
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.0",

--- a/frontend/src/utils/vtlAdapters.js
+++ b/frontend/src/utils/vtlAdapters.js
@@ -190,7 +190,7 @@ export class VelocitsAdapter extends VTLProcessorAdapter {
 
     try {
       // Dynamically import the TypeScript VTL processor
-      const { VTLProcessor } = await import('@fearlessfara/apigw-vtl-emulator');
+      const { VTLProcessor } = await import('apigw-vtl-emulator');
       this.processor = new VTLProcessor();
       this.ready = true;
       console.log('Velocits VTL Adapter initialized successfully');

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -16,11 +16,11 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@fearlessfara/apigw-vtl-emulator': path.resolve(__dirname, '../emulator/typescript/dist/index.js')
+      'apigw-vtl-emulator': path.resolve(__dirname, '../emulator/typescript/dist/index.js')
     }
   },
   optimizeDeps: {
-    include: ['@fearlessfara/apigw-vtl-emulator']
+    include: ['apigw-vtl-emulator']
   }
 })
 


### PR DESCRIPTION
Changed from @fearlessfara/apigw-vtl-emulator (scoped private) to apigw-vtl-emulator (public) to fix npm 402 Payment Required error.

Updated:
- Package name in package.json
- All import statements in README examples
- Workflow job name and environment URL
- Frontend dependency and imports
- Vite config alias and optimizeDeps

This allows the package to be published publicly without requiring npm organization payment.