### PR TITLE
chore(release): bump version to 1.1.0 and update dependencies

### DIFF
--- a/emulator/typescript/CHANGELOG.md
+++ b/emulator/typescript/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.0](https://github.com/fearlessfara/apigw-vtl-emulator/compare/v1.0.1...v1.1.0) (2025-01-27)
+
+
+### Chores
+
+* remove .nojekyll file ([50553a1](https://github.com/fearlessfara/apigw-vtl-emulator/commit/50553a1))
+
 ## [1.0.1](https://github.com/fearlessfara/apigw-vtl-emulator/compare/v1.0.0...v1.0.1) (2025-11-19)
 
 

--- a/emulator/typescript/package-lock.json
+++ b/emulator/typescript/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "@fearlessfara/apigw-vtl-emulator",
-  "version": "1.0.0",
+  "name": "apigw-vtl-emulator",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@fearlessfara/apigw-vtl-emulator",
-      "version": "1.0.0",
+      "name": "apigw-vtl-emulator",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@fearlessfara/velocits": "^1.0.0"
+        "@fearlessfara/velocits": "^1.2.0"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",

--- a/emulator/typescript/package.json
+++ b/emulator/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apigw-vtl-emulator",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "TypeScript/JavaScript implementation of AWS API Gateway VTL Emulator - works in Node.js and browsers",
   "type": "module",
   "main": "./dist/index.js",
@@ -61,7 +61,7 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@fearlessfara/velocits": "^1.0.0"
+    "@fearlessfara/velocits": "^1.2.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",


### PR DESCRIPTION
- Updated package version from 1.0.1 to 1.1.0 in package.json and package-lock.json
- Changed dependency version for @fearlessfara/velocits from ^1.0.0 to ^1.2.0

This release includes updates to the package version and dependencies to ensure compatibility and improvements.