### PR TITLE
Gate main merges on CI and require approval before npm publish

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -11,15 +11,19 @@ permissions:
   pull-requests: write
   id-token: write
 
+concurrency:
+  group: semantic-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment:
-      name: production
-      url: https://github.com/${{ github.repository }}/releases
     defaults:
       run:
         working-directory: emulator/typescript
+    outputs:
+      released: ${{ steps.semantic_release.outputs.released }}
+      version: ${{ steps.semantic_release.outputs.version }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -52,8 +56,38 @@ jobs:
         run: |
           node --input-type=module -e "import { appendFile } from 'node:fs/promises'; import semanticRelease from 'semantic-release'; const result = await semanticRelease(); if (result) { await appendFile(process.env.GITHUB_OUTPUT, 'released=true\n'); await appendFile(process.env.GITHUB_OUTPUT, 'version=' + result.nextRelease.version + '\n'); } else { await appendFile(process.env.GITHUB_OUTPUT, 'released=false\n'); }"
 
+  publish:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://github.com/${{ github.repository }}/releases
+    defaults:
+      run:
+        working-directory: emulator/typescript
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
       - name: Publish package
-        if: steps.semantic_release.outputs.released == 'true'
         env:
           NPM_CONFIG_PROVENANCE: true
         run: |


### PR DESCRIPTION
## Summary
- require the `Test TypeScript Package` and `Test Java VTL Processor` checks to pass before merges to `main`
- split semantic release into a versioning/release job and a separate `publish` job that waits on the `production` environment approval
- keep semantic-release responsible for automatic version calculation while ensuring npm publish happens only after explicit approval

## Validation
- verified `main` branch protection now requires both CI checks
- verified the `production` environment now requires reviewer approval from `fearlessfara`
- updated the release workflow in `.github/workflows/semantic-release.yml`

## Notes
- branch protection and environment approval were configured directly on GitHub in addition to the workflow change in this branch