### PR TITLE
Update frontend to apigw-vtl-emulator 1.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,35 @@ on:
       - main
 
 jobs:
+  test-frontend:
+    name: Test Frontend UI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright smoke tests
+        run: npm run test:e2e
+
   test-typescript:
     name: Test TypeScript Package
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,119 +1,80 @@
-# Contributing to VTL Emulator Pro
+# Contributing to VTL Emulator
 
-Thanks for your interest in contributing to **VTL Emulator Pro**! 🎉  
-Whether it's fixing a bug, improving the UI, adding a snippet, or extending the engine — you're very welcome.
+Thanks for contributing. This repository has two main parts:
 
----
+| Folder | Description |
+| --- | --- |
+| `frontend/` | React 19 + Vite UI for template editing and rendering |
+| `emulator/typescript/` | Published TypeScript package (`apigw-vtl-emulator`) |
+| `emulator/java/` | Legacy Java implementation and compatibility tests |
 
-## 📦 Repository Overview
+## Prerequisites
 
-This repo contains two main parts:
+- Node.js (repo uses `asdf` and pins versions in `.tool-versions`)
+- npm
+- Java 21+ for `emulator/java`
 
-| Folder        | Description                                |
-|---------------|--------------------------------------------|
-| `/emulator/`  | Core VTL engine (published on NPM)         |
-| `/frontend/`   | React-based frontend application            |
+## Local Development
 
----
+### Frontend
 
-## 🚀 Getting Started
-
-1. **Clone the repo**
-
-    ```
-    git clone https://github.com/fearlessfara/apigw-vtl-emulator.git
-    cd apigw-vtl-emulator
-    ```
-
-2. **Install dependencies**
-
-    Navigate to the engine directory and install:
-
-    ```
-    cd emulator
-    npm install
-    ```
-
-3. **Run tests**
-
-    ```
-    npm test
-    ```
-
-4. **Develop**
-
-    You can test changes by running the web UI locally. Open `index.html` in a browser or use a simple server like:
-
-    ```
-    npx live-server
-    # or
-    python3 -m http.server
-    ```
-
----
-
-## ✅ Contribution Guidelines
-
-### 🧠 Engine Contributions (`/emulator`)
-
-If you're modifying or extending the engine:
-
-- All changes must include **unit tests**
-- Use realistic `event` objects that mimic AWS API Gateway
-- Follow existing conventions and structure
-- Keep everything browser-compatible
-
-Tests go in:
-
-```
-emulator/tests/
+```bash
+cd frontend
+npm install
+npm run dev
 ```
 
-Use Mocha + Chai syntax.
+Build and smoke tests:
 
----
+```bash
+npm run build
+npx playwright install chromium
+npm run test:e2e
+```
 
-### 🌐 UI Contributions (web interface)
+### TypeScript Emulator Package
 
-When working on the frontend:
+```bash
+cd emulator/typescript
+npm install
+npm test
+npm run build
+```
 
-- Keep components modular and styled using Bootstrap 5
-- Avoid introducing non-essential dependencies
-- Prefer vanilla JS unless it greatly simplifies complexity
+### Java Emulator
 
----
+```bash
+cd emulator/java
+mvn clean test
+```
 
-## ✍️ Suggested Contributions
+## UI Contribution Guidelines
 
-Some great areas to contribute:
+- Keep the UX code-first and stable (editor workflow first, no visual churn for its own sake)
+- Use the existing custom CSS system and UI primitives in `frontend/src/components/ui/`
+- Radix primitives are used for dialog/dropdown/tabs/accordion behavior; keep styling in project CSS
+- Avoid reintroducing Bootstrap runtime/components
+- Add or update Playwright tests for user-facing behavior changes
 
-- Add or improve `$input` / `$util` / `$context` handlers
-- Add snippets for common API Gateway use-cases
-- Improve Monaco editor integration
-- Add formatting or linting helpers
-- Fix bugs or improve test coverage
+## Engine Contribution Guidelines
 
----
+- Include tests with all behavior changes
+- Keep AWS API Gateway compatibility as the baseline
+- Favor deterministic, browser-compatible behavior in the TypeScript package
 
-## 💡 Code Style
+## CI Expectations
 
-- JS: ES2020+ syntax
-- Use `npm` as your package manager
-- Keep functions pure and testable
-- Avoid bloated packages — everything runs in-browser
+PRs to `main` should pass:
 
----
+- Frontend build + Playwright smoke tests
+- TypeScript package checks/tests/build
+- Java tests/build
 
-## 📬 Opening a PR
+## Pull Request Checklist
 
-1. Push your branch to GitHub
-2. Open a Pull Request
-3. Include:
-    - A description of what you did
-    - Screenshots or examples if it's UI-related
-    - Linked issues (if any)
-    - Mention if it's a breaking change
+- Clear description of what changed and why
+- Screenshots or short recordings for visible UI changes
+- Updated docs when behavior/setup changes
+- Tests added or updated for new functionality
 
----
-
-Thanks for contributing! 🎉 Let’s make VTL dev tooling awesome together.
+Thanks again for helping improve VTL Emulator.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# VTL Emulator Pro
+# VTL Emulator
 
-**VTL Emulator Pro** is a browser-based editor and emulator
+**VTL Emulator** is a browser-based editor and emulator
 for [Apache Velocity Template Language (VTL)](https://velocity.apache.org/engine/1.7/user-guide.html), designed to
 simulate AWS API Gateway integration request/response templates.
 
@@ -116,7 +116,7 @@ The example above shows a VTL template that:
 
 ## 🚀 Quick Start (for the UI)
 
-The frontend is a React application. To run it locally:
+The frontend is a React + Vite application. To run it locally:
 
 ```bash
 git clone https://github.com/fearlessfara/apigw-vtl-emulator.git
@@ -125,7 +125,28 @@ npm install
 npm run dev
 ```
 
+Run UI smoke tests:
+
+```bash
+npx playwright install chromium
+npm run test:e2e
+```
+
+Build for production:
+
+```bash
+npm run build
+```
+
 Or visit the live version at **[https://vtlemulator.dev](https://vtlemulator.dev)**
+
+## 🧱 Frontend Stack
+
+- React 19 + Vite
+- Monaco Editor
+- Radix UI primitives (dialog, dropdown, tabs, accordion)
+- Custom CSS design system (no Bootstrap runtime/components)
+- Playwright smoke tests for core user flows
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This tool lets you:
 - Render and debug request/response flows
 - Manage variables for headers, query params, stage variables, and paths
 - Quickly test conditional blocks, loops, and transformations
-- Use the built-in Velocits TypeScript engine for fast browser-side rendering
+- Use the built-in Velocits TypeScript engine for fast browser-side rendering without engine switching setup
 
 ---
 
@@ -30,13 +30,15 @@ workflows.
 
 ## 🚀 Engine
 
-The VTL Emulator uses the Velocits TypeScript engine for VTL processing in the browser:
+The VTL Emulator uses a single built-in Velocits TypeScript engine for VTL processing in the browser:
 
 - **Type**: Pure TypeScript VTL processor
 - **Performance**: Fast
 - **Size**: Medium
 - **Features**: AWS API Gateway helpers, JSONPath support, browser-native execution
 - **Best for**: Fast development and testing without extra runtime assets
+
+There is no runtime engine selector in the UI anymore; the frontend always uses the Velocits-powered emulator package.
 
 ---
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -11,6 +11,8 @@ node_modules
 dist
 dist-ssr
 *.local
+playwright-report
+test-results
 
 # Editor directories and files
 .vscode/*
@@ -22,4 +24,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,8 +27,10 @@ The build output will be in the `dist` directory, ready for deployment to AWS Am
 - Monaco Editor with VTL syntax highlighting
 - Multiple template tabs
 - Body, Variables, Context, and Snippets editors
-- Velocits engine support
+- Built-in Velocits engine
 - Import/Export/Share functionality
 - Debug mode
 - Dark/Light theme
 - Responsive design
+
+The frontend uses `apigw-vtl-emulator@^1.2.0`, which now depends on the renamed `velocits` package. There is no engine selector in the UI.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,19 @@
 # VTL Emulator Frontend
 
-React + Vite frontend for the VTL Emulator application.
+React 19 + Vite frontend for the VTL Emulator application.
 
 ## Development
 
 ```bash
 npm install
 npm run dev
+```
+
+## UI Smoke Tests
+
+```bash
+npx playwright install chromium
+npm run test:e2e
 ```
 
 ## Build
@@ -32,5 +39,7 @@ The build output will be in the `dist` directory, ready for deployment to AWS Am
 - Debug mode
 - Dark/Light theme
 - Responsive design
+- Keyboard shortcuts (`Ctrl/Cmd+Enter`, `Ctrl/Cmd+S`, `Ctrl/Cmd+Shift+S`, `Ctrl/Cmd+/`)
+- Playwright smoke coverage for core flows
 
-The frontend uses `apigw-vtl-emulator@^1.2.0`, which now depends on the renamed `velocits` package. There is no engine selector in the UI.
+The frontend uses `apigw-vtl-emulator@^1.2.0`, which depends on the renamed `velocits` package. There is no engine selector in the UI.

--- a/frontend/SUMMARY.md
+++ b/frontend/SUMMARY.md
@@ -23,7 +23,7 @@ A complete React + Vite frontend that replicates all functionality from the orig
 
 ✅ **VTL Engines**
 - Velocits (TypeScript) engine support
-- Engine initialization with loading states
+- Single built-in engine flow with initialization/loading states
 
 ✅ **Core Functionality**
 - Render templates

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -41,7 +41,7 @@
       "@context": "https://schema.org",
       "@type": "WebApplication",
       "name": "VTL Emulator",
-      "alternateName": "VTL Emulator Pro",
+      "alternateName": "VTL Emulator",
       "url": "https://vtlemulator.dev",
       "description": "Free browser-based VTL (Velocity Template Language) emulator for AWS API Gateway. Test, debug, and preview VTL templates with real-time rendering.",
       "applicationCategory": "DeveloperApplication",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
-        "apigw-vtl-emulator": "^1.1.0",
+        "apigw-vtl-emulator": "^1.2.0",
         "bootstrap": "^5.3.3",
         "bootstrap-icons": "^1.11.0",
         "react": "^18.2.0",
@@ -319,38 +319,43 @@
       }
     },
     "node_modules/@chevrotain/cst-dts-gen": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
-      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.2.0.tgz",
+      "integrity": "sha512-ssJFvn/UXhQQeICw3SR/fZPmYVj+JM2mP+Lx7bZ51cOeHaMWOKp3AUMuyM3QR82aFFXTfcAp67P5GpPjGmbZWQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
+        "@chevrotain/gast": "11.2.0",
+        "@chevrotain/types": "11.2.0",
+        "lodash-es": "4.17.23"
       }
     },
     "node_modules/@chevrotain/gast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
-      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.2.0.tgz",
+      "integrity": "sha512-c+KoD6eSI1xjAZZoNUW+V0l13UEn+a4ShmUrjIKs1BeEWCji0Kwhmqn5FSx1K4BhWL7IQKlV7wLR4r8lLArORQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/types": "11.0.3",
-        "lodash-es": "4.17.21"
+        "@chevrotain/types": "11.2.0",
+        "lodash-es": "4.17.23"
       }
     },
     "node_modules/@chevrotain/regexp-to-ast": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
-      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.2.0.tgz",
+      "integrity": "sha512-lG73pBFqbXODTbXhdZwv0oyUaI+3Irm+uOv5/W79lI3g5hasYaJnVJOm3H2NkhA0Ef4XLBU4Scr7TJDJwgFkAw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/types": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
-      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.2.0.tgz",
+      "integrity": "sha512-vBMSj/lz/LqolbGQEHB0tlpW5BnljHVtp+kzjQfQU+5BtGMTuZCPVgaAjtKvQYXnHb/8i/02Kii00y0tsuwfsw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@chevrotain/utils": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
-      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.2.0.tgz",
+      "integrity": "sha512-+7whECg4yNWHottjvr2To2BRxL4XJVjIyyv5J4+bJ0iMOVU8j/8n1qPDLZS/90W/BObDR8VNL46lFbzY/Hosmw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -804,17 +809,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@fearlessfara/velocits": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@fearlessfara/velocits/-/velocits-1.2.0.tgz",
-      "integrity": "sha512-IWUeZlOBNqr/hAWvIQ8iAaOnux96Npo+tOPRDsaSO2tO1pdZQk/E5orlwESd85d8KtUZQ2v6GjB10mQhBEG9FA==",
-      "dependencies": {
-        "chevrotain": "^11.0.3"
-      },
-      "engines": {
-        "node": ">=22.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1557,11 +1551,12 @@
       }
     },
     "node_modules/apigw-vtl-emulator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/apigw-vtl-emulator/-/apigw-vtl-emulator-1.1.0.tgz",
-      "integrity": "sha512-4TOHXnU8vVxs+h/YDgX6O27CZFVR1XFRheoRc2U/K7Nt7GEVXCrVjBLl27itAA6wJmRzmsR5GPggkXtehttaNg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/apigw-vtl-emulator/-/apigw-vtl-emulator-1.2.0.tgz",
+      "integrity": "sha512-Jvqf4Y7PV5R8cLDmy8OhcNnffZx2uDNDEfAGX22MX02bOleMe5gW3tVC3TtMOBZoJXxe9FDyN5bKmaf5ltqJxg==",
+      "license": "MIT",
       "dependencies": {
-        "@fearlessfara/velocits": "^1.2.0"
+        "velocits": "^1.2.1"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -1934,16 +1929,17 @@
       }
     },
     "node_modules/chevrotain": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
-      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.2.0.tgz",
+      "integrity": "sha512-mHCHTxM51nCklUw9RzRVc0DLjAh/SAUPM4k/zMInlTIo25ldWXOZoPt7XEIk/LwoT4lFVmJcu9g5MHtx371x3A==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@chevrotain/cst-dts-gen": "11.0.3",
-        "@chevrotain/gast": "11.0.3",
-        "@chevrotain/regexp-to-ast": "11.0.3",
-        "@chevrotain/types": "11.0.3",
-        "@chevrotain/utils": "11.0.3",
-        "lodash-es": "4.17.21"
+        "@chevrotain/cst-dts-gen": "11.2.0",
+        "@chevrotain/gast": "11.2.0",
+        "@chevrotain/regexp-to-ast": "11.2.0",
+        "@chevrotain/types": "11.2.0",
+        "@chevrotain/utils": "11.2.0",
+        "lodash-es": "4.17.23"
       }
     },
     "node_modules/classnames": {
@@ -3683,9 +3679,10 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4977,6 +4974,18 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/velocits": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/velocits/-/velocits-1.2.1.tgz",
+      "integrity": "sha512-H4AsG76WMgKiCTW4AqBuw9GHqyBEHxkiw4yGo+lILHrcmsLXaAy75LDMExRPwmeniB5TgENKHADboMbKFaJZkg==",
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "^11.0.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/vite": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "^19.2.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.53.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.0",
@@ -990,6 +991,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/primitive": {
@@ -4581,6 +4598,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,17 +9,20 @@
       "version": "1.0.0",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
+        "@radix-ui/react-accordion": "^1.2.12",
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-tabs": "^1.1.13",
         "apigw-vtl-emulator": "^1.2.0",
-        "bootstrap": "^5.3.3",
         "bootstrap-icons": "^1.11.0",
-        "react": "^18.2.0",
-        "react-bootstrap": "^2.9.1",
-        "react-dom": "^18.2.0"
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4"
       },
       "devDependencies": {
-        "@types/react": "^18.2.43",
-        "@types/react-dom": "^18.2.17",
-        "@vitejs/plugin-react": "^4.2.1",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^5.1.0",
+        "baseline-browser-mapping": "^2.10.7",
         "eslint": "^8.55.0",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -28,13 +31,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -43,9 +46,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-      "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -53,21 +56,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-      "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
-        "@babel/helper-compilation-targets": "^7.27.2",
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helpers": "^7.28.4",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/traverse": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -84,14 +87,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -101,13 +104,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.27.2",
+        "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
@@ -128,29 +131,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -200,27 +203,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.4"
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -261,43 +264,34 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -305,9 +299,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -811,6 +805,44 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -960,89 +992,670 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
     },
-    "node_modules/@react-aria/ssr": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.10.tgz",
-      "integrity": "sha512-hvTm77Pf+pMBhuBm760Li0BVIO38jv1IBws1xFm1NoL26PU+fe+FMW5+VZWyANR6nYL65joaJKZqOdTQMkO9IQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
-      }
-    },
-    "node_modules/@restart/hooks": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.4.16.tgz",
-      "integrity": "sha512-f7aCv7c+nU/3mF7NWLtVVr0Ra80RqsO89hO72r+Y/nvQr5+q0UFGkocElTH6MJApvReVh6JHUFYn2cw1WdHF3w==",
+    "node_modules/@radix-ui/react-accordion": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
+      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
       "license": "MIT",
       "dependencies": {
-        "dequal": "^2.0.3"
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collapsible": "1.1.12",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@restart/ui": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
-      "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
+    "node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@popperjs/core": "^2.11.8",
-        "@react-aria/ssr": "^3.5.0",
-        "@restart/hooks": "^0.5.0",
-        "@types/warning": "^3.0.3",
-        "dequal": "^2.0.3",
-        "dom-helpers": "^5.2.0",
-        "uncontrollable": "^8.0.4",
-        "warning": "^4.0.3"
+        "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@restart/ui/node_modules/@restart/hooks": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
-      "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
+      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
       "license": "MIT",
       "dependencies": {
-        "dequal": "^2.0.3"
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
-        "react": ">=16.8.0"
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@restart/ui/node_modules/uncontrollable": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
-      "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
       "license": "MIT",
       "peerDependencies": {
-        "react": ">=16.14.0"
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
-      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
+      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -1354,15 +1967,6 @@
         "win32"
       ]
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1415,46 +2019,25 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.15",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.27",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
-      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
-    },
-    "node_modules/@types/react-transition-group": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/warning": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
-      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q==",
-      "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -1464,24 +2047,24 @@
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
-      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.2.0.tgz",
+      "integrity": "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.0",
+        "@babel/core": "^7.29.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
         "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@rolldown/pluginutils": "1.0.0-rc.3",
         "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.17.0"
+        "react-refresh": "^0.18.0"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn": {
@@ -1568,6 +2151,18 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -1741,32 +2336,16 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.30",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.30.tgz",
-      "integrity": "sha512-aTUKW4ptQhS64+v2d6IkPzymEzzhw+G0bA1g3uBRV3+ntkH+svttKseW5IOR4Ed6NUVKqnY7qT3dKvzQ7io4AA==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.7.tgz",
+      "integrity": "sha512-1ghYO3HnxGec0TCGBXiDLVns4eCSx4zJpxnHrlqFQajmhfKMQBzUGDdkMK7fUW7PTHTeLf+j87aTuKuuwWzMGw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
-      }
-    },
-    "node_modules/bootstrap": {
-      "version": "5.3.8",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
-      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/twbs"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/bootstrap"
-        }
-      ],
-      "license": "MIT",
-      "peerDependencies": {
-        "@popperjs/core": "^2.11.8"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bootstrap-icons": {
@@ -1797,9 +2376,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.0.tgz",
-      "integrity": "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
+      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
       "dev": true,
       "funding": [
         {
@@ -1817,11 +2396,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.25",
-        "caniuse-lite": "^1.0.30001754",
-        "electron-to-chromium": "^1.5.249",
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
         "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.1.4"
+        "update-browserslist-db": "^1.2.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1891,9 +2470,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001756",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001756.tgz",
-      "integrity": "sha512-4HnCNKbMLkLdhJz3TToeVWHSnfJvPaq6vu/eRP0Ahub/07n484XHhBF5AJoSGHdVrS8tKFauUQz8Bp9P7LVx7A==",
+      "version": "1.0.30001778",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001778.tgz",
+      "integrity": "sha512-PN7uxFL+ExFJO61aVmP1aIEG4i9whQd4eoSCebav62UwDyp5OHh06zN4jqKSMePVgxHifCw1QJxdRkA1Pisekg==",
       "dev": true,
       "funding": [
         {
@@ -1941,12 +2520,6 @@
         "@chevrotain/utils": "11.2.0",
         "lodash-es": "4.17.23"
       }
-    },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2001,6 +2574,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -2118,14 +2692,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -2138,16 +2709,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -2166,9 +2727,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.259",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.259.tgz",
-      "integrity": "sha512-I+oLXgpEJzD6Cwuwt1gYjxsDmu/S/Kd41mmLA3O+/uH2pFRO/DvOjUyGozL8j3KeLV6WyZ7ssPwELMsXCcsJAQ==",
+      "version": "1.5.313",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
+      "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2838,6 +3399,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -3121,15 +3691,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3560,6 +4121,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3695,6 +4257,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -3770,9 +4333,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
+      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3780,6 +4343,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4071,24 +4635,12 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types-extra": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.1.1.tgz",
-      "integrity": "sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==",
-      "license": "MIT",
-      "dependencies": {
-        "react-is": "^16.3.2",
-        "warning": "^4.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=0.14.0"
       }
     },
     "node_modules/punycode": {
@@ -4123,41 +4675,61 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-bootstrap": {
-      "version": "2.10.10",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.10.tgz",
-      "integrity": "sha512-gMckKUqn8aK/vCnfwoBpBVFUGT9SVQxwsYrp9yDHt0arXMamxALerliKBxr1TPbntirK/HGrUAHYbAeQTa9GHQ==",
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.24.7",
-        "@restart/hooks": "^0.4.9",
-        "@restart/ui": "^1.9.4",
-        "@types/prop-types": "^15.7.12",
-        "@types/react-transition-group": "^4.4.6",
-        "classnames": "^2.3.2",
-        "dom-helpers": "^5.2.1",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.8.1",
-        "prop-types-extra": "^1.1.0",
-        "react-transition-group": "^4.4.5",
-        "uncontrollable": "^7.2.1",
-        "warning": "^4.0.3"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.14.8",
-        "react": ">=16.14.0",
-        "react-dom": ">=16.14.0"
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4165,55 +4737,48 @@
         }
       }
     },
-    "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
       },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
-    },
-    "node_modules/react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
-      "license": "MIT"
-    },
-    "node_modules/react-refresh": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
-      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
-      "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
+        "node": ">=10"
       },
       "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -4438,13 +5003,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -4920,25 +5482,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/uncontrollable": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-7.2.1.tgz",
-      "integrity": "sha512-svtcfoTADIB0nT9nltgjujTi7BzVmwjZClOmskKu/E8FW9BXzg9os8OLr4f8Dlnk0rYWJIWr4wv9eKUXiQvQwQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.6.3",
-        "@types/react": ">=16.9.11",
-        "invariant": "^2.2.4",
-        "react-lifecycles-compat": "^3.0.4"
-      },
-      "peerDependencies": {
-        "react": ">=15.0.0"
-      }
-    },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
-      "integrity": "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -4974,6 +5521,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/velocits": {
@@ -5046,15 +5636,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/warning": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "apigw-vtl-emulator": "^1.1.0",
+    "apigw-vtl-emulator": "^1.2.0",
     "@monaco-editor/react": "^4.7.0",
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0"
+    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.12",
@@ -42,6 +43,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
+    "@playwright/test": "^1.53.2",
     "vite": "^5.0.8"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,18 +23,21 @@
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
-    "apigw-vtl-emulator": "^1.2.0",
+    "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@monaco-editor/react": "^4.7.0",
-    "bootstrap": "^5.3.3",
+    "apigw-vtl-emulator": "^1.2.0",
     "bootstrap-icons": "^1.11.0",
-    "react": "^18.2.0",
-    "react-bootstrap": "^2.9.1",
-    "react-dom": "^18.2.0"
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@types/react": "^18.2.43",
-    "@types/react-dom": "^18.2.17",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.0",
+    "baseline-browser-mapping": "^2.10.7",
     "eslint": "^8.55.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,0 +1,17 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  retries: 1,
+  use: {
+    baseURL: 'http://127.0.0.1:4174',
+    headless: true
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 4174 --strictPort --open false',
+    port: 4174,
+    reuseExistingServer: true,
+    timeout: 120_000
+  }
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,7 @@ import ResultPanel from './components/ResultPanel';
 import LoadingOverlay from './components/LoadingOverlay';
 import HelpModal from './components/HelpModal';
 import SettingsModal from './components/SettingsModal';
+import ToastStack from './components/ToastStack';
 import { loadSettings, saveSettings } from './utils/settings';
 import { VelocitsAdapter } from './utils/vtlAdapters';
 import { setupVelocityLanguage } from './utils/monacoConfig';
@@ -37,7 +38,16 @@ function App() {
   const [error, setError] = useState(null);
   const [showHelp, setShowHelp] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [toasts, setToasts] = useState([]);
   const monacoInstanceRef = useRef(null);
+
+  const addToast = useCallback((message, tone = 'info') => {
+    const id = Date.now() + Math.random();
+    setToasts((prev) => [...prev, { id, message, tone }]);
+    window.setTimeout(() => {
+      setToasts((prev) => prev.filter((toast) => toast.id !== id));
+    }, 2800);
+  }, []);
 
   // Initialize Monaco and engines
   useEffect(() => {
@@ -74,10 +84,11 @@ function App() {
         const config = JSON.parse(atob(configParam));
         loadConfiguration(config);
       } catch (error) {
-        console.error('Failed to load shared config:', error);
+          console.error('Failed to load shared config:', error);
+          addToast('Failed to load shared config from URL.', 'error');
+        }
       }
-    }
-  }, []);
+  }, [addToast]);
 
   // Apply theme
   useEffect(() => {
@@ -136,15 +147,16 @@ function App() {
 
   const render = useCallback(async () => {
     const startTime = performance.now();
-    let engine = engines[currentEngine];
+    let currentEngineInstance = engines[currentEngine];
     
-    if (!engine || !engine.isReady()) {
+    if (!currentEngineInstance || !currentEngineInstance.isReady()) {
       setLoading(true);
       setLoadingMessage('Initializing engine...');
       try {
-        await initializeEngine(currentEngine);
+        currentEngineInstance = await initializeEngine(currentEngine);
       } catch (error) {
         setError(`Engine initialization failed: ${error.message}`);
+        addToast(`Engine initialization failed: ${error.message}`, 'error');
         setLoading(false);
         return;
       }
@@ -161,8 +173,6 @@ function App() {
     }
 
     try {
-      const currentEngineInstance = engines[currentEngine];
-      
       // Merge variables into context
       let contextObj = {};
       try {
@@ -203,9 +213,10 @@ function App() {
       }
     } catch (error) {
       setError(error.message);
+      addToast(error.message, 'error');
       console.error('VTL Render Error:', error);
     }
-  }, [template, body, context, variables, currentEngine, engines, debugMode]);
+  }, [template, body, context, variables, currentEngine, engines, debugMode, addToast]);
 
   // Auto-render when content changes
   useEffect(() => {
@@ -227,13 +238,13 @@ function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [template, body, context, variables, autoRender, settings.autoRenderDelay]);
 
-  const updateSettings = (newSettings) => {
+  const updateSettings = useCallback((newSettings) => {
     const updated = { ...settings, ...newSettings };
     setSettings(updated);
     saveSettings(updated);
-  };
+  }, [settings]);
 
-  const loadConfiguration = (config) => {
+  const loadConfiguration = useCallback((config) => {
     if (config.template) {
       setTemplate(config.template);
     } else if (config.templates && config.templates.length > 0) {
@@ -244,9 +255,9 @@ function App() {
     if (config.context) setContext(config.context);
     if (config.variables) setVariables(config.variables);
     if (config.settings) updateSettings(config.settings);
-  };
+  }, [updateSettings]);
 
-  const exportConfiguration = () => {
+  const exportConfiguration = useCallback(() => {
     const config = {
       template,
       body,
@@ -263,9 +274,10 @@ function App() {
     a.download = `vtl-config-${new Date().toISOString().split('T')[0]}.json`;
     a.click();
     URL.revokeObjectURL(url);
-  };
+    addToast('Configuration exported.', 'success');
+  }, [template, body, context, variables, settings, addToast]);
 
-  const shareConfiguration = () => {
+  const shareConfiguration = useCallback(() => {
     const config = {
       template,
       body,
@@ -277,14 +289,49 @@ function App() {
       const encodedConfig = btoa(JSON.stringify(config));
       const shareUrl = `${window.location.origin}${window.location.pathname}?config=${encodedConfig}`;
       navigator.clipboard.writeText(shareUrl).then(() => {
-        // Show success toast
+        addToast('Share URL copied to clipboard.', 'success');
       }).catch(() => {
         prompt('Copy this URL to share your configuration:', shareUrl);
+        addToast('Clipboard unavailable. Share URL shown in prompt.', 'info');
       });
     } catch (e) {
       setError('Failed to generate share URL: ' + e.message);
+      addToast('Failed to generate share URL.', 'error');
     }
-  };
+  }, [template, body, context, variables, addToast]);
+
+  useEffect(() => {
+    const handleKeyboardShortcuts = (event) => {
+      const isPrimary = event.metaKey || event.ctrlKey;
+      if (!isPrimary) {
+        return;
+      }
+
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        render();
+        return;
+      }
+
+      if (event.key.toLowerCase() === 's') {
+        event.preventDefault();
+        if (event.shiftKey) {
+          shareConfiguration();
+        } else {
+          exportConfiguration();
+        }
+        return;
+      }
+
+      if (event.key === '/') {
+        event.preventDefault();
+        setShowHelp(true);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyboardShortcuts);
+    return () => window.removeEventListener('keydown', handleKeyboardShortcuts);
+  }, [render, exportConfiguration, shareConfiguration]);
 
   const getCurrentEngineInstance = () => {
     return engines[currentEngine];
@@ -293,6 +340,10 @@ function App() {
   return (
     <div className="app-shell">
       <LoadingOverlay show={loading} message={loadingMessage} />
+      <ToastStack
+        toasts={toasts}
+        onDismiss={(id) => setToasts((prev) => prev.filter((toast) => toast.id !== id))}
+      />
       
       <Header 
         onThemeToggle={() => {
@@ -328,8 +379,10 @@ function App() {
                 try {
                   const config = JSON.parse(event.target.result);
                   loadConfiguration(config);
+                  addToast('Configuration imported.', 'success');
                 } catch (error) {
                   setError('Invalid configuration file: ' + error.message);
+                  addToast('Invalid configuration file.', 'error');
                 }
               };
               reader.readAsText(file);
@@ -369,19 +422,24 @@ function App() {
           <div className="custom-col custom-col-lg-4 workspace-column">
             <ResultPanel
               result={result}
-              onCopy={() => {
-                navigator.clipboard.writeText(result);
+              onCopy={(content) => {
+                navigator.clipboard.writeText(content ?? result);
+                addToast('Output copied.', 'success');
               }}
-              onDownload={() => {
-                const blob = new Blob([result], { type: 'text/plain' });
+              onDownload={(content) => {
+                const blob = new Blob([content ?? result], { type: 'text/plain' });
                 const url = URL.createObjectURL(blob);
                 const a = document.createElement('a');
                 a.href = url;
                 a.download = 'vtl-result.txt';
                 a.click();
                 URL.revokeObjectURL(url);
+                addToast('Output downloaded.', 'success');
               }}
-              onClear={() => setResult('Click "Render" to see the VTL output here...')}
+              onClear={() => {
+                setResult('Click "Render" to see the VTL output here...');
+                addToast('Output cleared.', 'info');
+              }}
               debugMode={debugMode}
               debugSteps={debugSteps}
               error={error}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,7 +30,7 @@ function App() {
   const [autoRenderTimeout, setAutoRenderTimeout] = useState(null);
   const [debugMode, setDebugMode] = useState(false);
   const [debugSteps, setDebugSteps] = useState([]);
-  const [currentEngine, setCurrentEngine] = useState('velocits');
+  const currentEngine = 'velocits';
   const [engines, setEngines] = useState({});
   const [loading, setLoading] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState('Loading...');
@@ -127,17 +127,6 @@ function App() {
       throw error;
     } finally {
       setLoading(false);
-    }
-  };
-
-  const switchEngine = async (engineType) => {
-    if (engineType === currentEngine) return;
-
-    try {
-      await initializeEngine(engineType);
-      setCurrentEngine(engineType);
-    } catch (error) {
-      setError(`Failed to switch engine: ${error.message}`);
     }
   };
 
@@ -327,8 +316,6 @@ function App() {
               setAutoRenderTimeout(null);
             }
           }}
-          currentEngine={currentEngine}
-          onEngineChange={switchEngine}
           onImport={() => {
             const input = document.createElement('input');
             input.type = 'file';

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,7 @@ import HelpModal from './components/HelpModal';
 import SettingsModal from './components/SettingsModal';
 import { loadSettings, saveSettings } from './utils/settings';
 import { VelocitsAdapter } from './utils/vtlAdapters';
-import { setupVelocityLanguage, getEditorOptions } from './utils/monacoConfig';
+import { setupVelocityLanguage } from './utils/monacoConfig';
 import { loader } from '@monaco-editor/react';
 
 function App() {
@@ -291,7 +291,7 @@ function App() {
   };
 
   return (
-    <div style={{minHeight: '100vh', background: 'var(--bg-primary)', display: 'flex', flexDirection: 'column'}}>
+    <div className="app-shell">
       <LoadingOverlay show={loading} message={loadingMessage} />
       
       <Header 
@@ -304,7 +304,7 @@ function App() {
         onSettingsClick={() => setShowSettings(true)}
       />
 
-      <div className="custom-container-fluid" style={{maxWidth: '1800px', flex: 1, display: 'flex', flexDirection: 'column'}}>
+      <div className="custom-container-fluid app-main-shell">
         <Toolbar
           onRender={render}
           autoRender={autoRender}
@@ -345,8 +345,8 @@ function App() {
           engineInfo={getCurrentEngineInstance()?.getDisplayName() || 'Not initialized'}
         />
 
-        <div className="custom-row" style={{flex: 1, margin: 0, alignItems: 'stretch', minHeight: 0}}>
-          <div className="custom-col custom-col-lg-8" style={{display: 'flex', flexDirection: 'column', minHeight: 0}}>
+        <div className="custom-row app-workspace-row">
+          <div className="custom-col custom-col-lg-8 workspace-column">
             <EditorTabs
               template={template}
               onTemplateChange={setTemplate}
@@ -366,7 +366,7 @@ function App() {
             />
           </div>
           
-          <div className="custom-col custom-col-lg-4" style={{display: 'flex', flexDirection: 'column', minHeight: 0}}>
+          <div className="custom-col custom-col-lg-4 workspace-column">
             <ResultPanel
               result={result}
               onCopy={() => {

--- a/frontend/src/components/EditorTabs.jsx
+++ b/frontend/src/components/EditorTabs.jsx
@@ -24,6 +24,9 @@ function EditorTabs({
   const [templateValid, setTemplateValid] = useState(true);
   const [bodyValid, setBodyValid] = useState(true);
   const [contextValid, setContextValid] = useState(true);
+  const [templateNotice, setTemplateNotice] = useState(null);
+  const [bodyNotice, setBodyNotice] = useState(null);
+  const [contextNotice, setContextNotice] = useState(null);
   const templateEditorRef = useRef(null);
   const bodyEditorRef = useRef(null);
   const contextEditorRef = useRef(null);
@@ -45,18 +48,21 @@ function EditorTabs({
     const blockStarts = (value.match(/#(if|foreach|macro)\b/g) || []).length;
     const blockEnds = (value.match(/#end\b/g) || []).length;
     setTemplateValid(blockStarts === blockEnds);
+    setTemplateNotice(null);
   };
 
   const handleBodyChange = (value) => {
     onBodyChange(value);
     const validation = validateJSON(value);
     setBodyValid(validation.valid);
+    setBodyNotice(null);
   };
 
   const handleContextChange = (value) => {
     onContextChange(value);
     const validation = validateJSON(value);
     setContextValid(validation.valid);
+    setContextNotice(null);
   };
 
   const handleFormatTemplate = async () => {
@@ -84,9 +90,9 @@ function EditorTabs({
     }
 
     if (issues.length > 0) {
-      alert('Template Validation Issues:\n' + issues.join('\n'));
+      setTemplateNotice({ tone: 'error', message: issues.join(' ') });
     } else {
-      alert('Template validation passed!');
+      setTemplateNotice({ tone: 'success', message: 'Template structure looks valid.' });
     }
   };
 
@@ -94,8 +100,9 @@ function EditorTabs({
     try {
       const formatted = formatJSON(body);
       onBodyChange(formatted);
+      setBodyNotice({ tone: 'success', message: 'Body JSON formatted.' });
     } catch (error) {
-      alert('Invalid JSON cannot be formatted');
+      setBodyNotice({ tone: 'error', message: 'Body JSON is invalid and cannot be formatted.' });
     }
   };
 
@@ -103,8 +110,9 @@ function EditorTabs({
     try {
       const minified = minifyJSON(body);
       onBodyChange(minified);
+      setBodyNotice({ tone: 'success', message: 'Body JSON minified.' });
     } catch (error) {
-      alert('Invalid JSON cannot be minified');
+      setBodyNotice({ tone: 'error', message: 'Body JSON is invalid and cannot be minified.' });
     }
   };
 
@@ -112,13 +120,15 @@ function EditorTabs({
     try {
       const formatted = formatJSON(context);
       onContextChange(formatted);
+      setContextNotice({ tone: 'success', message: 'Context JSON formatted.' });
     } catch (error) {
-      alert('Invalid JSON cannot be formatted');
+      setContextNotice({ tone: 'error', message: 'Context JSON is invalid and cannot be formatted.' });
     }
   };
 
   const handleLoadSampleContext = () => {
     onContextChange(getDefaultContext());
+    setContextNotice({ tone: 'success', message: 'Sample context loaded.' });
   };
 
   return (
@@ -156,10 +166,10 @@ function EditorTabs({
         </Tab>
       </Tabs>
 
-      <div className="modern-tab-content" style={{flex: 1, display: 'flex', flexDirection: 'column', minHeight: 0}}>
+      <div className="modern-tab-content editor-content-shell">
         {currentTab === 'template' && (
-          <div style={{display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0}}>
-            <div className={`modern-editor-container ${templateValid ? 'valid' : 'invalid'}`} style={{flex: 1, minHeight: 0, marginBottom: '1rem'}}>
+          <div className="tab-panel-shell">
+            <div className={`modern-editor-container ${templateValid ? 'valid' : 'invalid'}`}>
               <Editor
                 height="100%"
                 language="velocity"
@@ -171,8 +181,8 @@ function EditorTabs({
               />
               <div className={`status-indicator ${templateValid ? '' : 'error'}`}></div>
             </div>
-            <div className="d-flex justify-content-between align-items-center" style={{flexWrap: 'wrap', gap: '0.5rem', flexShrink: 0, marginTop: '0.5rem'}}>
-              <div className="d-flex gap-2">
+            <div className="editor-footer-row d-flex justify-content-between align-items-center">
+              <div className="d-flex gap-2 editor-footer-actions">
                 <Button variant="outline-secondary" size="sm" onClick={handleFormatTemplate}>
                   <i className="bi bi-code me-1"></i>Format
                 </Button>
@@ -180,20 +190,21 @@ function EditorTabs({
                   <i className="bi bi-check-circle me-1"></i>Validate
                 </Button>
               </div>
-              <div style={{fontSize: '0.75rem', color: 'var(--text-secondary)', display: 'flex', alignItems: 'center', gap: '0.5rem', flexWrap: 'wrap'}}>
-                <kbd style={{padding: '0.25rem 0.5rem', background: 'var(--bg-secondary)', borderRadius: '4px', fontSize: '0.75rem', color: 'var(--text-primary)', border: '1px solid var(--border-color)', fontFamily: 'monospace', fontWeight: 500, display: 'inline-block'}}>Ctrl+Space</kbd>
-                <span style={{color: 'var(--text-secondary)'}}>for autocomplete</span>
-                <span style={{color: 'var(--text-secondary)'}}>|</span>
-                <kbd style={{padding: '0.25rem 0.5rem', background: 'var(--bg-secondary)', borderRadius: '4px', fontSize: '0.75rem', color: 'var(--text-primary)', border: '1px solid var(--border-color)', fontFamily: 'monospace', fontWeight: 500, display: 'inline-block'}}>Ctrl+F</kbd>
-                <span style={{color: 'var(--text-secondary)'}}>to find</span>
+              <div className="editor-shortcuts-hint">
+                <kbd>Ctrl+Space</kbd>
+                <span>for autocomplete</span>
+                <span>|</span>
+                <kbd>Ctrl+F</kbd>
+                <span>to find</span>
               </div>
             </div>
+            {templateNotice && <div className={`editor-notice editor-notice-${templateNotice.tone}`}>{templateNotice.message}</div>}
           </div>
         )}
 
         {currentTab === 'body' && (
-          <div style={{display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0}}>
-            <div className={`modern-editor-container ${bodyValid ? 'valid' : 'invalid'}`} style={{flex: 1, minHeight: 0, marginBottom: '1rem'}}>
+          <div className="tab-panel-shell">
+            <div className={`modern-editor-container ${bodyValid ? 'valid' : 'invalid'}`}>
               <Editor
                 height="100%"
                 language="json"
@@ -205,7 +216,7 @@ function EditorTabs({
               />
               <div className={`status-indicator ${bodyValid ? '' : 'error'}`}></div>
             </div>
-            <div className="d-flex gap-2" style={{flexShrink: 0, marginTop: '0.5rem'}}>
+            <div className="d-flex gap-2 editor-footer-actions">
               <Button variant="outline-secondary" size="sm" onClick={handleFormatBody}>
                 <i className="bi bi-braces me-1"></i>Format JSON
               </Button>
@@ -213,11 +224,12 @@ function EditorTabs({
                 <i className="bi bi-dash-square me-1"></i>Minify
               </Button>
             </div>
+            {bodyNotice && <div className={`editor-notice editor-notice-${bodyNotice.tone}`}>{bodyNotice.message}</div>}
           </div>
         )}
 
         {currentTab === 'variables' && (
-          <div style={{display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'auto'}}>
+          <div className="tab-panel-shell tab-panel-scrollable">
             <VariablesTab
               variables={variables}
               onVariablesChange={onVariablesChange}
@@ -226,8 +238,8 @@ function EditorTabs({
         )}
 
         {currentTab === 'context' && (
-          <div style={{display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0}}>
-            <div className={`modern-editor-container ${contextValid ? 'valid' : 'invalid'}`} style={{flex: 1, minHeight: 0, marginBottom: '1rem'}}>
+          <div className="tab-panel-shell">
+            <div className={`modern-editor-container ${contextValid ? 'valid' : 'invalid'}`}>
               <Editor
                 height="100%"
                 language="json"
@@ -239,7 +251,7 @@ function EditorTabs({
               />
               <div className={`status-indicator ${contextValid ? '' : 'error'}`}></div>
             </div>
-            <div className="d-flex gap-2" style={{flexShrink: 0, marginTop: '0.5rem'}}>
+            <div className="d-flex gap-2 editor-footer-actions">
               <Button variant="outline-secondary" size="sm" onClick={handleLoadSampleContext}>
                 <i className="bi bi-file-code me-1"></i>Load Sample
               </Button>
@@ -247,11 +259,12 @@ function EditorTabs({
                 <i className="bi bi-braces me-1"></i>Format JSON
               </Button>
             </div>
+            {contextNotice && <div className={`editor-notice editor-notice-${contextNotice.tone}`}>{contextNotice.message}</div>}
           </div>
         )}
 
         {currentTab === 'snippets' && (
-          <div style={{display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0}}>
+          <div className="tab-panel-shell">
             <SnippetsTab onSnippetInsert={onSnippetInsert} />
           </div>
         )}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -4,24 +4,23 @@ import './ui/Layout.css';
 function Header({ onThemeToggle, theme, onHelpClick, onSettingsClick }) {
   return (
     <div className="app-header">
-      <div className="custom-container-fluid" style={{maxWidth: '1600px', padding: '0 1.5rem'}}>
-        <div className="d-flex justify-content-between align-items-center">
-          <h1 style={{margin: 0}} className="d-flex align-items-center">
+      <div className="custom-container-fluid app-shell-width header-shell">
+        <div className="header-row d-flex justify-content-between align-items-center">
+          <h1 className="header-title d-flex align-items-center">
             <img 
               src="/favicon.ico" 
               alt="VTL Emulator" 
               className="header-icon"
-              style={{width: '1.5rem', height: '1.5rem', marginRight: '0.5rem', borderRadius: '0.375rem'}}
             />
-            VTL Emulator
+            <span>VTL Emulator</span>
           </h1>
-          <div className="d-flex gap-1 align-items-center">
+          <div className="header-actions d-flex align-items-center">
             <Button 
               variant="outline-secondary" 
               size="sm" 
               onClick={onThemeToggle}
               title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-              style={{border: '1px solid var(--border-color)', background: 'var(--bg-secondary)', padding: '0.375rem 0.5rem'}}
+              className="header-icon-button"
             >
               <i className={`bi ${theme === 'dark' ? 'bi-sun' : 'bi-moon'}`}></i>
             </Button>
@@ -30,7 +29,7 @@ function Header({ onThemeToggle, theme, onHelpClick, onSettingsClick }) {
               size="sm" 
               onClick={onHelpClick}
               title="Help"
-              style={{border: '1px solid var(--border-color)', background: 'var(--bg-secondary)', padding: '0.375rem 0.5rem'}}
+              className="header-icon-button"
             >
               <i className="bi bi-question-circle"></i>
             </Button>
@@ -39,7 +38,7 @@ function Header({ onThemeToggle, theme, onHelpClick, onSettingsClick }) {
               size="sm" 
               onClick={onSettingsClick}
               title="Settings"
-              style={{border: '1px solid var(--border-color)', background: 'var(--bg-secondary)', padding: '0.375rem 0.5rem'}}
+              className="header-icon-button"
             >
               <i className="bi bi-gear"></i>
             </Button>
@@ -51,4 +50,3 @@ function Header({ onThemeToggle, theme, onHelpClick, onSettingsClick }) {
 }
 
 export default Header;
-

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -20,6 +20,7 @@ function Header({ onThemeToggle, theme, onHelpClick, onSettingsClick }) {
               size="sm" 
               onClick={onThemeToggle}
               title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+              aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
               className="header-icon-button"
             >
               <i className={`bi ${theme === 'dark' ? 'bi-sun' : 'bi-moon'}`}></i>
@@ -29,6 +30,7 @@ function Header({ onThemeToggle, theme, onHelpClick, onSettingsClick }) {
               size="sm" 
               onClick={onHelpClick}
               title="Help"
+              aria-label="Help"
               className="header-icon-button"
             >
               <i className="bi bi-question-circle"></i>
@@ -38,6 +40,7 @@ function Header({ onThemeToggle, theme, onHelpClick, onSettingsClick }) {
               size="sm" 
               onClick={onSettingsClick}
               title="Settings"
+              aria-label="Settings"
               className="header-icon-button"
             >
               <i className="bi bi-gear"></i>

--- a/frontend/src/components/HelpModal.jsx
+++ b/frontend/src/components/HelpModal.jsx
@@ -26,12 +26,13 @@ function HelpModal({ show, onHide }) {
             <AccordionHeader>Keyboard Shortcuts</AccordionHeader>
             <AccordionBody>
               <ul>
-                <li><kbd>Ctrl + Enter</kbd> - Render template</li>
+                <li><kbd>Ctrl/Cmd + Enter</kbd> - Render template</li>
                 <li><kbd>Ctrl + Space</kbd> - Show autocomplete</li>
                 <li><kbd>Ctrl + F</kbd> - Find in editor</li>
                 <li><kbd>Ctrl + H</kbd> - Find and replace</li>
-                <li><kbd>Ctrl + S</kbd> - Export configuration</li>
-                <li><kbd>F11</kbd> - Toggle fullscreen</li>
+                <li><kbd>Ctrl/Cmd + S</kbd> - Export configuration</li>
+                <li><kbd>Ctrl/Cmd + Shift + S</kbd> - Share configuration</li>
+                <li><kbd>Ctrl/Cmd + /</kbd> - Open help</li>
               </ul>
             </AccordionBody>
           </AccordionItem>
@@ -42,4 +43,3 @@ function HelpModal({ show, onHide }) {
 }
 
 export default HelpModal;
-

--- a/frontend/src/components/LoadingOverlay.jsx
+++ b/frontend/src/components/LoadingOverlay.jsx
@@ -4,19 +4,13 @@ function LoadingOverlay({ show, message = 'Loading...' }) {
   return (
     <div className="modern-loading-overlay">
       <div className="modern-loading-content">
-        <div className="spinner-border text-primary mb-3" role="status">
-          <span className="visually-hidden">Loading...</span>
+        <div className="loading-spinner" role="status" aria-live="polite">
+          <span className="sr-only">Loading...</span>
         </div>
         <h5>Initializing VTL Engine</h5>
         <p>{message}</p>
-        <div className="loading-progress">
-          <div className="progress" style={{height: '4px'}}>
-            <div 
-              className="progress-bar progress-bar-striped progress-bar-animated" 
-              role="progressbar" 
-              style={{width: '0%'}}
-            ></div>
-          </div>
+        <div className="loading-progress" aria-hidden="true">
+          <div className="loading-progress-bar"></div>
         </div>
       </div>
     </div>
@@ -24,4 +18,3 @@ function LoadingOverlay({ show, message = 'Loading...' }) {
 }
 
 export default LoadingOverlay;
-

--- a/frontend/src/components/ResultPanel.jsx
+++ b/frontend/src/components/ResultPanel.jsx
@@ -12,13 +12,13 @@ function ResultPanel({
   onErrorDismiss 
 }) {
   return (
-    <div style={{display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0, gap: '1rem'}}>
-      <div style={{flexShrink: 0}}>
-        <div className="d-flex justify-content-between align-items-center">
-          <h6 style={{margin: 0, fontWeight: 600, fontSize: '0.875rem', color: 'var(--text-primary)'}}>
+    <div className="result-panel-shell">
+      <div className="panel-header panel-header-tight">
+        <div className="d-flex justify-content-between align-items-center panel-header-row">
+          <h6 className="panel-title">
             <i className="bi bi-terminal"></i>Output
           </h6>
-          <div className="d-flex gap-1">
+          <div className="panel-actions d-flex gap-1">
             <Button variant="outline-secondary" size="sm" onClick={onCopy} title="Copy">
               <i className="bi bi-clipboard"></i>
             </Button>
@@ -31,7 +31,7 @@ function ResultPanel({
           </div>
         </div>
       </div>
-      <div className="modern-result-panel" id="result" style={{flex: 1, minHeight: 0}}>
+      <div className="modern-result-panel" id="result">
         {result}
       </div>
       
@@ -51,10 +51,7 @@ function ResultPanel({
       {error && (
         <div className="modern-error-panel">
           <strong><i className="bi bi-exclamation-triangle"></i>Error:</strong> {error}
-          <button 
-            onClick={onErrorDismiss}
-            style={{background: 'transparent', border: 'none', color: 'inherit', float: 'right', cursor: 'pointer', padding: '0.25rem'}}
-          >
+          <button onClick={onErrorDismiss} className="error-dismiss-button">
             <i className="bi bi-x"></i>
           </button>
         </div>
@@ -64,4 +61,3 @@ function ResultPanel({
 }
 
 export default ResultPanel;
-

--- a/frontend/src/components/ResultPanel.jsx
+++ b/frontend/src/components/ResultPanel.jsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from 'react';
 import { Button } from './ui';
 import './ui/Layout.css';
 
@@ -11,6 +12,22 @@ function ResultPanel({
   error,
   onErrorDismiss 
 }) {
+  const [wrapOutput, setWrapOutput] = useState(false);
+  const [prettyJson, setPrettyJson] = useState(true);
+  const [fontScale, setFontScale] = useState(14);
+
+  const displayResult = useMemo(() => {
+    if (!prettyJson) {
+      return result;
+    }
+
+    try {
+      return JSON.stringify(JSON.parse(result), null, 2);
+    } catch {
+      return result;
+    }
+  }, [result, prettyJson]);
+
   return (
     <div className="result-panel-shell">
       <div className="panel-header panel-header-tight">
@@ -19,10 +36,10 @@ function ResultPanel({
             <i className="bi bi-terminal"></i>Output
           </h6>
           <div className="panel-actions d-flex gap-1">
-            <Button variant="outline-secondary" size="sm" onClick={onCopy} title="Copy">
+            <Button variant="outline-secondary" size="sm" onClick={() => onCopy(displayResult)} title="Copy">
               <i className="bi bi-clipboard"></i>
             </Button>
-            <Button variant="outline-secondary" size="sm" onClick={onDownload} title="Download">
+            <Button variant="outline-secondary" size="sm" onClick={() => onDownload(displayResult)} title="Download">
               <i className="bi bi-download"></i>
             </Button>
             <Button variant="outline-secondary" size="sm" onClick={onClear} title="Clear">
@@ -31,8 +48,23 @@ function ResultPanel({
           </div>
         </div>
       </div>
-      <div className="modern-result-panel" id="result">
-        {result}
+
+      <div className="result-tools">
+        <button className={`result-chip ${prettyJson ? 'active' : ''}`} onClick={() => setPrettyJson((v) => !v)}>
+          <i className="bi bi-braces"></i>Pretty JSON
+        </button>
+        <button className={`result-chip ${wrapOutput ? 'active' : ''}`} onClick={() => setWrapOutput((v) => !v)}>
+          <i className="bi bi-text-wrap"></i>Wrap
+        </button>
+        <div className="result-font-size">
+          <button className="result-chip" onClick={() => setFontScale((v) => Math.max(12, v - 1))}>A-</button>
+          <span>{fontScale}px</span>
+          <button className="result-chip" onClick={() => setFontScale((v) => Math.min(18, v + 1))}>A+</button>
+        </div>
+      </div>
+
+      <div className={`modern-result-panel ${wrapOutput ? 'result-wrap' : ''}`} id="result" style={{ fontSize: `${fontScale}px` }}>
+        {displayResult}
       </div>
       
       {debugMode && (

--- a/frontend/src/components/SettingsModal.jsx
+++ b/frontend/src/components/SettingsModal.jsx
@@ -22,8 +22,8 @@ function SettingsModal({ show, onHide, settings, onSave }) {
     }>
       <ModalBody>
         <form id="settingsForm">
-          <div style={{marginBottom: '1rem'}}>
-            <label style={{display: 'block', marginBottom: '0.5rem', fontWeight: 500}}>
+          <div className="settings-field">
+            <label className="settings-label">
               Auto-render delay (ms)
             </label>
             <input
@@ -32,33 +32,17 @@ function SettingsModal({ show, onHide, settings, onSave }) {
               min="100"
               max="5000"
               defaultValue={settings.autoRenderDelay}
-              style={{
-                width: '100%',
-                padding: '0.5rem 0.75rem',
-                border: '1px solid var(--border-color)',
-                borderRadius: 'var(--radius)',
-                background: 'var(--bg-elevated)',
-                color: 'var(--text-primary)',
-                fontSize: '0.875rem'
-              }}
+              className="form-control"
             />
           </div>
-          <div style={{marginBottom: '1rem'}}>
-            <label style={{display: 'block', marginBottom: '0.5rem', fontWeight: 500}}>
+          <div className="settings-field">
+            <label className="settings-label">
               Editor font size
             </label>
             <select
               name="fontSize"
               defaultValue={settings.fontSize}
-              style={{
-                width: '100%',
-                padding: '0.5rem 0.75rem',
-                border: '1px solid var(--border-color)',
-                borderRadius: 'var(--radius)',
-                background: 'var(--bg-elevated)',
-                color: 'var(--text-primary)',
-                fontSize: '0.875rem'
-              }}
+              className="form-select"
             >
               <option value="12">12px</option>
               <option value="14">14px</option>
@@ -66,8 +50,8 @@ function SettingsModal({ show, onHide, settings, onSave }) {
               <option value="18">18px</option>
             </select>
           </div>
-          <div style={{marginBottom: '1rem'}}>
-            <label style={{display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer'}}>
+          <div className="settings-field settings-toggle-group">
+            <label className="settings-toggle">
               <input
                 type="checkbox"
                 name="lineNumbers"
@@ -76,8 +60,8 @@ function SettingsModal({ show, onHide, settings, onSave }) {
               <span>Show line numbers</span>
             </label>
           </div>
-          <div style={{marginBottom: '1rem'}}>
-            <label style={{display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer'}}>
+          <div className="settings-field settings-toggle-group">
+            <label className="settings-toggle">
               <input
                 type="checkbox"
                 name="minimap"
@@ -86,8 +70,8 @@ function SettingsModal({ show, onHide, settings, onSave }) {
               <span>Show minimap</span>
             </label>
           </div>
-          <div>
-            <label style={{display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer'}}>
+          <div className="settings-toggle-group">
+            <label className="settings-toggle">
               <input
                 type="checkbox"
                 name="wordWrap"
@@ -107,4 +91,3 @@ function SettingsModal({ show, onHide, settings, onSave }) {
 }
 
 export default SettingsModal;
-

--- a/frontend/src/components/SnippetsTab.jsx
+++ b/frontend/src/components/SnippetsTab.jsx
@@ -10,23 +10,15 @@ function SnippetsTab({ onSnippetInsert }) {
   );
 
   return (
-    <div>
-      <div className="mb-3">
-        <h6 style={{fontWeight: 600, fontSize: '0.875rem', color: 'var(--text-primary)', marginBottom: '0.75rem'}}>VTL Snippet Library</h6>
+    <div className="snippets-shell">
+      <div className="panel-header panel-header-spaced">
+        <h6 className="panel-title">VTL Snippet Library</h6>
         <input
           type="text"
           placeholder="Search snippets..."
           value={searchTerm}
           onChange={(e) => setSearchTerm(e.target.value)}
-          style={{
-            width: '100%',
-            padding: '0.5rem 0.75rem',
-            border: '1px solid var(--border-color)',
-            borderRadius: 'var(--radius-sm)',
-            background: 'var(--bg-elevated)',
-            color: 'var(--text-primary)',
-            fontSize: '0.875rem'
-          }}
+          className="form-control snippets-search"
         />
       </div>
       <div className="modern-snippet-library">
@@ -46,4 +38,3 @@ function SnippetsTab({ onSnippetInsert }) {
 }
 
 export default SnippetsTab;
-

--- a/frontend/src/components/ToastStack.jsx
+++ b/frontend/src/components/ToastStack.jsx
@@ -1,0 +1,24 @@
+function ToastStack({ toasts, onDismiss }) {
+  if (!toasts.length) {
+    return null;
+  }
+
+  return (
+    <div className="toast-stack" role="status" aria-live="polite" aria-atomic="false">
+      {toasts.map((toast) => (
+        <div key={toast.id} className={`toast-item toast-item-${toast.tone}`}>
+          <div className="toast-message">{toast.message}</div>
+          <button
+            className="toast-dismiss"
+            onClick={() => onDismiss(toast.id)}
+            aria-label="Dismiss notification"
+          >
+            <i className="bi bi-x"></i>
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default ToastStack;

--- a/frontend/src/components/Toolbar.jsx
+++ b/frontend/src/components/Toolbar.jsx
@@ -4,8 +4,6 @@ function Toolbar({
   onRender,
   autoRender,
   onAutoRenderToggle,
-  currentEngine,
-  onEngineChange,
   onImport,
   onExport,
   onShare,
@@ -30,17 +28,6 @@ function Toolbar({
       >
         <i className="bi bi-arrow-repeat"></i>{autoRender ? 'Auto ON' : 'Auto'}
       </Button>
-      <div className="vr"></div>
-      <div className="modern-engine-selector">
-        <label htmlFor="engineSelect">Engine:</label>
-        <select
-          id="engineSelect"
-          value={currentEngine}
-          onChange={(e) => onEngineChange(e.target.value)}
-        >
-          <option value="velocits">Velocits (TypeScript) ⚡ Recommended</option>
-        </select>
-      </div>
       <div className="vr"></div>
       <Dropdown>
         <DropdownToggle 

--- a/frontend/src/components/Toolbar.jsx
+++ b/frontend/src/components/Toolbar.jsx
@@ -15,47 +15,51 @@ function Toolbar({
 }) {
   return (
     <div className="modern-toolbar">
-      <Button 
-        variant="primary" 
-        onClick={onRender}
-      >
-        <i className="bi bi-play-fill"></i>Render
-      </Button>
-      <Button 
-        variant={autoRender ? "success" : "outline-success"}
-        onClick={onAutoRenderToggle}
-        className={autoRender ? "active" : ""}
-      >
-        <i className="bi bi-arrow-repeat"></i>{autoRender ? 'Auto ON' : 'Auto'}
-      </Button>
-      <div className="vr"></div>
-      <Dropdown>
-        <DropdownToggle 
-          variant="outline-secondary" 
-          size="sm"
+      <div className="toolbar-action-group">
+        <Button 
+          variant="primary" 
+          onClick={onRender}
         >
-          <i className="bi bi-list"></i>
-        </DropdownToggle>
-        <DropdownMenu align="end">
-          <DropdownItem onClick={onImport}>
-            <i className="bi bi-upload"></i>Import
-          </DropdownItem>
-          <DropdownItem onClick={onExport}>
-            <i className="bi bi-download"></i>Export
-          </DropdownItem>
-          <DropdownItem onClick={onShare}>
-            <i className="bi bi-share"></i>Share
-          </DropdownItem>
-        </DropdownMenu>
-      </Dropdown>
+          <i className="bi bi-play-fill"></i>Render
+        </Button>
+        <Button 
+          variant={autoRender ? "success" : "outline-success"}
+          onClick={onAutoRenderToggle}
+          className={autoRender ? "active" : ""}
+        >
+          <i className="bi bi-arrow-repeat"></i>{autoRender ? 'Auto ON' : 'Auto'}
+        </Button>
+      </div>
       <div className="vr"></div>
-      <Button 
-        variant="outline-info" 
-        onClick={onDebugToggle}
-        className={debugMode ? "active" : ""}
-      >
-        <i className="bi bi-bug"></i>Debug
-      </Button>
+      <div className="toolbar-action-group toolbar-action-group-secondary">
+        <Dropdown>
+          <DropdownToggle 
+            variant="outline-secondary" 
+            size="sm"
+            className="toolbar-menu-button"
+          >
+            <i className="bi bi-list"></i>Actions
+          </DropdownToggle>
+          <DropdownMenu align="end">
+            <DropdownItem onClick={onImport}>
+              <i className="bi bi-upload"></i>Import
+            </DropdownItem>
+            <DropdownItem onClick={onExport}>
+              <i className="bi bi-download"></i>Export
+            </DropdownItem>
+            <DropdownItem onClick={onShare}>
+              <i className="bi bi-share"></i>Share
+            </DropdownItem>
+          </DropdownMenu>
+        </Dropdown>
+        <Button 
+          variant="outline-info" 
+          onClick={onDebugToggle}
+          className={debugMode ? "active" : ""}
+        >
+          <i className="bi bi-bug"></i>Debug
+        </Button>
+      </div>
       <div className="modern-performance-stats">
         <span>Render: {renderTime}ms</span>
         <span>Size: {templateSize} chars</span>

--- a/frontend/src/components/VariablesTab.jsx
+++ b/frontend/src/components/VariablesTab.jsx
@@ -5,6 +5,8 @@ import './ui/Layout.css';
 function VariablesTab({ variables, onVariablesChange }) {
   // Track stable IDs for each entry - key is the variable key, value is a unique ID
   const entryIdMapRef = useRef({});
+  const [notice, setNotice] = useState(null);
+  const [confirmClear, setConfirmClear] = useState(false);
   
   // Initialize entry IDs
   useEffect(() => {
@@ -36,6 +38,7 @@ function VariablesTab({ variables, onVariablesChange }) {
         [newKey]: ''
       }
     });
+    setNotice({ tone: 'success', message: `Added a new ${group} variable.` });
   };
 
   const updateVariable = (group, oldKey, newKey, newValue) => {
@@ -62,6 +65,7 @@ function VariablesTab({ variables, onVariablesChange }) {
       ...variables,
       [group]: newVars
     });
+    setNotice(null);
   };
 
   const removeVariable = (group, key) => {
@@ -74,23 +78,24 @@ function VariablesTab({ variables, onVariablesChange }) {
       ...variables,
       [group]: newVars
     });
+    setNotice({ tone: 'success', message: `Removed ${group} variable "${key}".` });
   };
 
   const clearAll = () => {
-    if (window.confirm('Are you sure you want to clear all variables?')) {
-      entryIdMapRef.current = {
-        querystring: {},
-        path: {},
-        header: {},
-        stage: {}
-      };
-      onVariablesChange({
-        querystring: {},
-        path: {},
-        header: {},
-        stage: {}
-      });
-    }
+    entryIdMapRef.current = {
+      querystring: {},
+      path: {},
+      header: {},
+      stage: {}
+    };
+    onVariablesChange({
+      querystring: {},
+      path: {},
+      header: {},
+      stage: {}
+    });
+    setConfirmClear(false);
+    setNotice({ tone: 'success', message: 'Cleared all variable groups.' });
   };
 
   const importVariables = () => {
@@ -109,9 +114,10 @@ function VariablesTab({ variables, onVariablesChange }) {
               ...variables,
               ...data
             });
+            setNotice({ tone: 'success', message: 'Variables imported successfully.' });
           }
         } catch (error) {
-          alert('Error importing variables: ' + error.message);
+          setNotice({ tone: 'error', message: `Error importing variables: ${error.message}` });
         }
       };
       reader.readAsText(file);
@@ -141,7 +147,6 @@ function VariablesTab({ variables, onVariablesChange }) {
             
             return (
               <div key={entryId} className="modern-variable-row">
-                <i className="bi bi-grip-vertical drag-handle"></i>
                 <input
                   className="form-control var-key"
                   placeholder="Key"
@@ -180,10 +185,13 @@ function VariablesTab({ variables, onVariablesChange }) {
   };
 
   return (
-    <div>
-      <div className="d-flex justify-content-between align-items-center" style={{marginBottom: '1rem'}}>
-        <h6 style={{margin: 0, fontWeight: 600, fontSize: '0.875rem', color: 'var(--text-primary)'}}>Variable Groups</h6>
-        <div className="d-flex gap-1">
+    <div className="variables-shell">
+      <div className="panel-header panel-header-spaced variables-header">
+        <div>
+          <h6 className="panel-title">Variable Groups</h6>
+          <p className="panel-subtitle">Manage headers, query params, stage values, and path inputs.</p>
+        </div>
+        <div className="d-flex gap-1 variables-actions">
           <Button 
             variant="primary" 
             size="sm"
@@ -194,11 +202,23 @@ function VariablesTab({ variables, onVariablesChange }) {
           <Button variant="outline-secondary" size="sm" onClick={importVariables}>
             <i className="bi bi-upload"></i>Import
           </Button>
-          <Button variant="outline-secondary" size="sm" onClick={clearAll}>
-            <i className="bi bi-trash"></i>Clear All
-          </Button>
+          {confirmClear ? (
+            <>
+              <Button variant="outline-danger" size="sm" onClick={clearAll}>
+                <i className="bi bi-trash"></i>Confirm Clear
+              </Button>
+              <Button variant="outline-secondary" size="sm" onClick={() => setConfirmClear(false)}>
+                Cancel
+              </Button>
+            </>
+          ) : (
+            <Button variant="outline-secondary" size="sm" onClick={() => setConfirmClear(true)}>
+              <i className="bi bi-trash"></i>Clear All
+            </Button>
+          )}
         </div>
       </div>
+      {notice && <div className={`editor-notice editor-notice-${notice.tone}`}>{notice.message}</div>}
       <div id="variableGroups">
         <VariableGroup group="querystring" label="Query String Parameters" icon="bi-link-45deg" />
         <VariableGroup group="path" label="Path Parameters" icon="bi-signpost" />

--- a/frontend/src/components/ui/Accordion.css
+++ b/frontend/src/components/ui/Accordion.css
@@ -11,7 +11,14 @@
   background: var(--bg-elevated);
 }
 
+.custom-accordion-header-shell {
+  margin: 0;
+}
+
 .custom-accordion-header {
+  all: unset;
+  box-sizing: border-box;
+  width: 100%;
   padding: 1rem 1.25rem;
   background: var(--bg-secondary);
   cursor: pointer;
@@ -26,6 +33,31 @@
 
 .custom-accordion-header:hover {
   background: var(--bg-hover);
+}
+
+.custom-accordion-header:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--accent-light);
+}
+
+.custom-accordion-chevron {
+  transition: transform 0.2s ease;
+}
+
+.custom-accordion-item[data-state="open"] .custom-accordion-chevron {
+  transform: rotate(90deg);
+}
+
+.custom-accordion-content {
+  overflow: hidden;
+}
+
+.custom-accordion-content[data-state="open"] {
+  animation: accordion-down 0.2s ease-out;
+}
+
+.custom-accordion-content[data-state="closed"] {
+  animation: accordion-up 0.2s ease-out;
 }
 
 .custom-accordion-body {
@@ -57,3 +89,22 @@
   font-family: monospace;
 }
 
+@keyframes accordion-down {
+  from {
+    height: 0;
+  }
+
+  to {
+    height: var(--radix-accordion-content-height);
+  }
+}
+
+@keyframes accordion-up {
+  from {
+    height: var(--radix-accordion-content-height);
+  }
+
+  to {
+    height: 0;
+  }
+}

--- a/frontend/src/components/ui/Accordion.jsx
+++ b/frontend/src/components/ui/Accordion.jsx
@@ -1,40 +1,38 @@
-import { useState, Children, cloneElement } from 'react';
+import { Children } from 'react';
+import * as RadixAccordion from '@radix-ui/react-accordion';
 import './Accordion.css';
 
 export default function Accordion({ children, defaultActiveKey, ...props }) {
-  const [activeKey, setActiveKey] = useState(defaultActiveKey);
-
   return (
-    <div className="custom-accordion" {...props}>
-      {Children.map(children, (child, index) => {
-        if (!child) return null;
-        const key = child.props?.eventKey || index.toString();
-        return cloneElement(child, {
-          active: activeKey === key,
-          onToggle: () => setActiveKey(activeKey === key ? null : key)
-        });
-      })}
-    </div>
+    <RadixAccordion.Root
+      type="single"
+      collapsible
+      defaultValue={defaultActiveKey}
+      className="custom-accordion"
+      {...props}
+    >
+      {children}
+    </RadixAccordion.Root>
   );
 }
 
-export function AccordionItem({ children, eventKey, active, onToggle, ...props }) {
+export function AccordionItem({ children, eventKey, ...props }) {
   const childrenArray = Children.toArray(children);
   const header = childrenArray.find(child => child.type === AccordionHeader);
   const body = childrenArray.find(child => child.type === AccordionBody);
 
   return (
-    <div className="custom-accordion-item" {...props}>
-      <div className="custom-accordion-header" onClick={onToggle}>
-        <span>{header?.props?.children}</span>
-        <i className={`bi bi-chevron-${active ? 'down' : 'right'}`}></i>
-      </div>
-      {active && body && (
-        <div className="custom-accordion-body">
-          {body.props?.children}
-        </div>
-      )}
-    </div>
+    <RadixAccordion.Item className="custom-accordion-item" value={eventKey} {...props}>
+      <RadixAccordion.Header className="custom-accordion-header-shell">
+        <RadixAccordion.Trigger className="custom-accordion-header">
+          <span>{header?.props?.children}</span>
+          <i className="bi bi-chevron-right custom-accordion-chevron"></i>
+        </RadixAccordion.Trigger>
+      </RadixAccordion.Header>
+      <RadixAccordion.Content className="custom-accordion-content">
+        <div className="custom-accordion-body">{body?.props?.children}</div>
+      </RadixAccordion.Content>
+    </RadixAccordion.Item>
   );
 }
 
@@ -45,4 +43,3 @@ export function AccordionHeader({ children, ...props }) {
 export function AccordionBody({ children, ...props }) {
   return <div {...props}>{children}</div>;
 }
-

--- a/frontend/src/components/ui/Button.css
+++ b/frontend/src/components/ui/Button.css
@@ -11,11 +11,17 @@
   white-space: nowrap;
   transition: all 0.2s ease;
   line-height: 1.5;
+  min-height: 2.25rem;
 }
 
 .custom-btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.custom-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-light);
 }
 
 /* Sizes */
@@ -78,6 +84,7 @@
 .custom-btn-outline-secondary:hover:not(:disabled) {
   background: var(--bg-hover);
   border-color: var(--border-hover);
+  transform: translateY(-1px);
 }
 
 .custom-btn-outline-info {
@@ -102,4 +109,3 @@
   background: var(--error);
   color: white;
 }
-

--- a/frontend/src/components/ui/Button.jsx
+++ b/frontend/src/components/ui/Button.jsx
@@ -1,6 +1,7 @@
+import { forwardRef } from 'react';
 import './Button.css';
 
-export default function Button({ 
+const Button = forwardRef(function Button({ 
   children, 
   variant = 'secondary', 
   size = 'md',
@@ -10,7 +11,7 @@ export default function Button({
   disabled = false,
   type = 'button',
   ...props 
-}) {
+}, ref) {
   const baseClass = 'custom-btn';
   const variantClass = `custom-btn-${variant}`;
   const sizeClass = `custom-btn-${size}`;
@@ -22,10 +23,12 @@ export default function Button({
       onClick={onClick}
       disabled={disabled}
       style={style}
+      ref={ref}
       {...props}
     >
       {children}
     </button>
   );
-}
+});
 
+export default Button;

--- a/frontend/src/components/ui/Dropdown.css
+++ b/frontend/src/components/ui/Dropdown.css
@@ -8,13 +8,6 @@
   display: inline-block;
 }
 
-.custom-dropdown-menu-wrapper {
-  position: absolute;
-  top: 100%;
-  z-index: 1000;
-  margin-top: 0.25rem;
-}
-
 .custom-dropdown-menu {
   background: var(--bg-elevated);
   border: 1px solid var(--border-color);
@@ -22,6 +15,8 @@
   box-shadow: var(--shadow-md);
   padding: 0.5rem;
   min-width: 150px;
+  animation: dropdown-fade-in 0.16s ease;
+  z-index: 1000;
 }
 
 .custom-dropdown-menu-start {
@@ -41,6 +36,8 @@
   align-items: center;
   transition: all 0.2s ease;
   cursor: pointer;
+  gap: 0.5rem;
+  white-space: nowrap;
 }
 
 .custom-dropdown-item:hover {
@@ -53,8 +50,57 @@
   color: var(--text-primary);
 }
 
+.custom-dropdown-item:focus-visible {
+  outline: none;
+  background: var(--bg-secondary);
+  box-shadow: inset 0 0 0 1px var(--border-hover);
+}
+
+.custom-dropdown-menu[data-side="top"] {
+  animation: dropdown-fade-up 0.16s ease;
+}
+
+.custom-dropdown-menu[data-side="bottom"] {
+  animation: dropdown-fade-down 0.16s ease;
+}
+
+@keyframes dropdown-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes dropdown-fade-down {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes dropdown-fade-up {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 [data-theme="dark"] .custom-dropdown-menu {
   background: var(--bg-elevated);
   border-color: var(--border-color);
 }
-

--- a/frontend/src/components/ui/Dropdown.jsx
+++ b/frontend/src/components/ui/Dropdown.jsx
@@ -1,82 +1,51 @@
-import { useState, useRef, useEffect, createContext, useContext } from 'react';
+import * as RadixDropdownMenu from '@radix-ui/react-dropdown-menu';
 import Button from './Button';
 import './Dropdown.css';
 
-const DropdownContext = createContext();
-
 export default function Dropdown({ children, ...props }) {
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef(null);
-
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-        setIsOpen(false);
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('mousedown', handleClickOutside);
-    }
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [isOpen]);
-
-  const toggle = () => setIsOpen(!isOpen);
-  const close = () => setIsOpen(false);
-
   return (
-    <DropdownContext.Provider value={{ isOpen, toggle, close }}>
-      <div className="custom-dropdown-wrapper" ref={dropdownRef} {...props}>
+    <RadixDropdownMenu.Root modal={false}>
+      <div className="custom-dropdown-wrapper" {...props}>
         {children}
       </div>
-    </DropdownContext.Provider>
+    </RadixDropdownMenu.Root>
   );
 }
 
 export function DropdownToggle({ children, as: Component = Button, ...props }) {
-  const { isOpen, toggle } = useContext(DropdownContext);
-
   return (
-    <Component onClick={toggle} {...props}>
-      {children}
-    </Component>
+    <RadixDropdownMenu.Trigger asChild>
+      <Component {...props}>{children}</Component>
+    </RadixDropdownMenu.Trigger>
   );
 }
 
 export function DropdownMenu({ children, align = 'end', ...props }) {
-  const { isOpen, close } = useContext(DropdownContext);
-
-  if (!isOpen) return null;
+  const alignValue = align === 'start' ? 'start' : 'end';
 
   return (
-    <div className="custom-dropdown-menu-wrapper">
-      <div 
-        className={`custom-dropdown-menu custom-dropdown-menu-${align}`} 
+    <RadixDropdownMenu.Portal>
+      <RadixDropdownMenu.Content
+        className={`custom-dropdown-menu custom-dropdown-menu-${alignValue}`}
+        align={alignValue}
+        sideOffset={6}
+        collisionPadding={8}
         {...props}
       >
         {children}
-      </div>
-    </div>
+      </RadixDropdownMenu.Content>
+    </RadixDropdownMenu.Portal>
   );
 }
 
 export function DropdownItem({ children, onClick, ...props }) {
-  const { close } = useContext(DropdownContext);
-
   return (
-    <div 
-      className="custom-dropdown-item" 
-      onClick={(e) => {
-        onClick?.(e);
-        close();
-      }}
+    <RadixDropdownMenu.Item
+      className="custom-dropdown-item"
+      onSelect={onClick}
       {...props}
     >
       {children}
-    </div>
+    </RadixDropdownMenu.Item>
   );
 }
-

--- a/frontend/src/components/ui/Layout.css
+++ b/frontend/src/components/ui/Layout.css
@@ -75,7 +75,8 @@
   width: 1px;
   height: 1.5rem;
   background: var(--border-color);
-  margin: 0 0.5rem;
+  margin: 0 0.25rem;
   align-self: center;
+  flex-shrink: 0;
 }
 

--- a/frontend/src/components/ui/Modal.css
+++ b/frontend/src/components/ui/Modal.css
@@ -14,6 +14,10 @@
 }
 
 .custom-modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   background: var(--bg-elevated);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-lg);
@@ -23,6 +27,9 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  border: 1px solid var(--border-color);
+  animation: modal-rise-in 0.18s ease;
+  z-index: 1060;
 }
 
 .custom-modal-sm {
@@ -78,6 +85,11 @@
   color: var(--text-primary);
 }
 
+.custom-modal-close:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px var(--accent-light);
+}
+
 .custom-modal-body {
   padding: 1.5rem;
   overflow-y: auto;
@@ -98,3 +110,21 @@
   background: rgba(0, 0, 0, 0.7);
 }
 
+@keyframes modal-rise-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, calc(-50% + 10px)) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+@media (max-width: 768px) {
+  .custom-modal {
+    width: calc(100% - 1.5rem);
+    max-height: calc(100vh - 1.5rem);
+  }
+}

--- a/frontend/src/components/ui/Modal.jsx
+++ b/frontend/src/components/ui/Modal.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import Button from './Button';
+import * as RadixDialog from '@radix-ui/react-dialog';
 import './Modal.css';
 
 export default function Modal({ show, onHide, title, children, size = 'md', ...props }) {
@@ -23,31 +23,22 @@ export default function Modal({ show, onHide, title, children, size = 'md', ...p
   );
 
   return (
-    <div className="custom-modal-overlay" onClick={onHide}>
-      <div 
-        className={`custom-modal custom-modal-${size}`}
-        onClick={(e) => e.stopPropagation()}
-        {...props}
-      >
-        {title && (
-          <div className="custom-modal-header">
-            <h5 className="custom-modal-title">{title}</h5>
-            <button 
-              className="custom-modal-close" 
-              onClick={onHide}
-              aria-label="Close"
-            >
-              <i className="bi bi-x"></i>
-            </button>
-          </div>
-        )}
-        {hasModalComponents ? children : (
-          <div className="custom-modal-body">
-            {children}
-          </div>
-        )}
-      </div>
-    </div>
+    <RadixDialog.Root open={show} onOpenChange={(open) => !open && onHide?.()}>
+      <RadixDialog.Portal>
+        <RadixDialog.Overlay className="custom-modal-overlay" />
+        <RadixDialog.Content className={`custom-modal custom-modal-${size}`} {...props}>
+          {title && (
+            <div className="custom-modal-header">
+              <RadixDialog.Title className="custom-modal-title">{title}</RadixDialog.Title>
+              <RadixDialog.Close className="custom-modal-close" aria-label="Close">
+                <i className="bi bi-x"></i>
+              </RadixDialog.Close>
+            </div>
+          )}
+          {hasModalComponents ? children : <div className="custom-modal-body">{children}</div>}
+        </RadixDialog.Content>
+      </RadixDialog.Portal>
+    </RadixDialog.Root>
   );
 }
 
@@ -66,4 +57,3 @@ export function ModalBody({ children, ...props }) {
 export function ModalFooter({ children, ...props }) {
   return <div className="custom-modal-footer" {...props}>{children}</div>;
 }
-

--- a/frontend/src/components/ui/Tabs.css
+++ b/frontend/src/components/ui/Tabs.css
@@ -24,6 +24,7 @@
   align-items: center;
   gap: 0.5rem;
   font-family: inherit;
+  position: relative;
 }
 
 .custom-tab:hover {
@@ -31,10 +32,16 @@
   background: var(--bg-secondary);
 }
 
-.custom-tab.active {
+.custom-tab.active,
+.custom-tab[data-state="active"] {
   color: var(--aws-orange);
   background: transparent;
   border-bottom-color: var(--aws-orange);
   font-weight: 600;
 }
 
+.custom-tab:focus-visible {
+  outline: none;
+  background: var(--bg-secondary);
+  box-shadow: inset 0 0 0 1px var(--border-hover);
+}

--- a/frontend/src/components/ui/Tabs.jsx
+++ b/frontend/src/components/ui/Tabs.jsx
@@ -1,22 +1,35 @@
+import { Children, cloneElement } from 'react';
+import * as RadixTabs from '@radix-ui/react-tabs';
 import './Tabs.css';
 
 export default function Tabs({ children, className = '', ...props }) {
+  const tabs = Children.toArray(children).filter(Boolean);
+  const activeIndex = Math.max(0, tabs.findIndex((tab) => tab.props?.active));
+  const activeValue = `tab-${activeIndex}`;
+
   return (
-    <div className={`custom-tabs ${className}`} {...props}>
-      {children}
-    </div>
+    <RadixTabs.Root value={activeValue}>
+      <RadixTabs.List className={`custom-tabs ${className}`} {...props}>
+        {tabs.map((tab, index) =>
+          cloneElement(tab, {
+            tabValue: `tab-${index}`,
+            key: tab.key ?? `tab-${index}`
+          })
+        )}
+      </RadixTabs.List>
+    </RadixTabs.Root>
   );
 }
 
-export function Tab({ children, active, onClick, ...props }) {
+export function Tab({ children, active, onClick, tabValue, ...props }) {
   return (
-    <button
+    <RadixTabs.Trigger
+      value={tabValue}
       className={`custom-tab ${active ? 'active' : ''}`}
       onClick={onClick}
       {...props}
     >
       {children}
-    </button>
+    </RadixTabs.Trigger>
   );
 }
-

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -89,6 +89,15 @@ body {
     -moz-osx-font-smoothing: grayscale;
 }
 
+#root {
+    min-height: 100vh;
+}
+
+.app-shell-width {
+    max-width: 1600px;
+    margin: 0 auto;
+}
+
 /* Header */
 .app-header {
     background: var(--bg-elevated);
@@ -118,6 +127,24 @@ body {
     letter-spacing: -0.02em;
 }
 
+.header-shell {
+    padding-top: 0.125rem;
+    padding-bottom: 0.125rem;
+}
+
+.header-row {
+    gap: 1rem;
+    min-height: 3rem;
+}
+
+.header-title {
+    margin: 0;
+}
+
+.header-title span {
+    display: inline-block;
+}
+
 [data-theme="dark"] .app-header h1 {
     color: #F9FAFB;
 }
@@ -125,6 +152,23 @@ body {
 .app-header .header-icon {
     color: var(--aws-orange);
     font-size: 1.5rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    margin-right: 0.5rem;
+    border-radius: 0.375rem;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.04);
+}
+
+.header-actions {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.header-icon-button {
+    min-width: 2.5rem;
+    min-height: 2.5rem;
+    padding: 0.5rem;
+    border-radius: var(--radius);
 }
 
 /* Toolbar */
@@ -132,18 +176,37 @@ body {
     background: var(--bg-elevated);
     border: 1px solid var(--border-color);
     border-radius: var(--radius-lg);
-    padding: 0.625rem 1rem;
+    padding: 0.75rem 1.25rem;
     margin-bottom: 1rem;
     display: flex;
-    gap: 0.5rem;
+    gap: 0.75rem;
     align-items: center;
     flex-wrap: wrap;
     box-shadow: var(--shadow-sm);
     flex-shrink: 0;
+    position: sticky;
+    top: 4.75rem;
+    z-index: 90;
 }
 
 .modern-toolbar > * {
     flex-shrink: 0;
+}
+
+.toolbar-action-group,
+.toolbar-action-group-secondary {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+/* Explicit spacing between toolbar buttons */
+.modern-toolbar .toolbar-action-group .custom-btn:not(:last-child) {
+    margin-right: 0.75rem;
+}
+
+.modern-toolbar .toolbar-action-group-secondary .custom-dropdown-wrapper {
+    margin-right: 0.75rem;
 }
 
 .modern-toolbar .btn {
@@ -216,89 +279,10 @@ body {
     color: white;
 }
 
-/* Dropdown Menu */
-.modern-toolbar .dropdown-menu {
-    background: var(--bg-elevated);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius);
-    box-shadow: var(--shadow-md);
-    padding: 0.5rem;
-    margin-top: 0.25rem;
-    min-width: 150px;
-}
-
-.modern-toolbar .dropdown-item {
-    color: var(--text-primary);
-    padding: 0.5rem 0.75rem;
-    border-radius: var(--radius-sm);
-    font-size: 0.875rem;
-    display: flex;
-    align-items: center;
-    transition: all 0.2s ease;
-}
-
-.modern-toolbar .dropdown-item:hover {
-    background: var(--bg-secondary);
-    color: var(--text-primary);
-}
-
-.modern-toolbar .dropdown-item:active {
-    background: var(--bg-hover);
-    color: var(--text-primary);
-}
-
-[data-theme="dark"] .modern-toolbar .dropdown-menu {
-    background: var(--bg-elevated);
-    border-color: var(--border-color);
-}
-
-/* Engine Selector */
-.modern-engine-selector {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0;
-    background: transparent;
-    border: none;
-    border-radius: 0;
-}
-
-.modern-engine-selector label {
-    font-size: 0.8125rem;
-    font-weight: 500;
-    color: var(--text-secondary);
-    margin: 0;
-    white-space: nowrap;
-}
-
-.modern-engine-selector select {
-    border: 1px solid var(--border-color);
-    background: var(--bg-secondary);
-    color: var(--text-primary);
-    font-size: 0.8125rem;
-    font-weight: 500;
-    cursor: pointer;
-    font-family: inherit;
-    padding: 0.5rem 1rem;
-    border-radius: var(--radius);
-    transition: all 0.2s ease;
-}
-
-.modern-engine-selector select:hover {
-    background: var(--bg-hover);
-    border-color: var(--border-hover);
-}
-
-.modern-engine-selector select:focus {
-    outline: none;
-    border-color: var(--aws-orange);
-    box-shadow: 0 0 0 2px var(--aws-orange-light);
-}
-
 /* Performance Stats */
 .modern-performance-stats {
     display: flex;
-    gap: 0.5rem;
+    gap: 0.625rem;
     align-items: center;
     margin-left: auto;
     font-size: 0.75rem;
@@ -312,6 +296,47 @@ body {
     font-weight: 500;
     color: var(--text-secondary);
     white-space: nowrap;
+}
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.panel-header-tight {
+    flex-shrink: 0;
+}
+
+.panel-header-spaced {
+    margin-bottom: 1rem;
+}
+
+.panel-header-row {
+    width: 100%;
+    gap: 1rem;
+}
+
+.panel-title {
+    margin: 0;
+    font-weight: 600;
+    font-size: 0.875rem;
+    color: var(--text-primary);
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.panel-subtitle {
+    margin-top: 0.25rem;
+    color: var(--text-secondary);
+    font-size: 0.8125rem;
+}
+
+.panel-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
 }
 
 /* Template Tabs */
@@ -429,6 +454,22 @@ body {
     overflow: hidden;
 }
 
+.editor-content-shell {
+    gap: 0.875rem;
+}
+
+.tab-panel-shell {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    gap: 0.875rem;
+}
+
+.tab-panel-scrollable {
+    overflow: auto;
+}
+
 /* Editor Container */
 .modern-editor-container {
     border: 1px solid var(--border-color);
@@ -497,6 +538,56 @@ body {
     box-shadow: 0 0 0 2px var(--bg-elevated), 0 0 0 4px var(--error-light);
 }
 
+.editor-footer-row {
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.editor-footer-actions {
+    flex-wrap: wrap;
+}
+
+.editor-shortcuts-hint {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+}
+
+.editor-shortcuts-hint kbd {
+    padding: 0.25rem 0.5rem;
+    background: var(--bg-secondary);
+    border-radius: 4px;
+    color: var(--text-primary);
+    border: 1px solid var(--border-color);
+    font-family: monospace;
+    font-weight: 500;
+    display: inline-block;
+}
+
+.editor-notice {
+    border-radius: var(--radius);
+    border: 1px solid var(--border-color);
+    padding: 0.75rem 0.875rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+}
+
+.editor-notice-success {
+    background: var(--success-light);
+    border-color: color-mix(in srgb, var(--success) 40%, var(--border-color));
+    color: var(--success);
+}
+
+.editor-notice-error {
+    background: var(--error-light);
+    border-color: color-mix(in srgb, var(--error) 40%, var(--border-color));
+    color: var(--error);
+}
+
 /* Result Panel */
 .modern-result-panel {
     background: var(--bg-secondary);
@@ -515,6 +606,14 @@ body {
     min-height: 0;
 }
 
+.result-panel-shell {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    min-height: 0;
+    gap: 1rem;
+}
+
 .modern-result-panel::before {
     content: '';
     position: absolute;
@@ -524,6 +623,14 @@ body {
     height: 4px;
     background: linear-gradient(90deg, var(--aws-orange) 0%, var(--aws-blue) 100%);
     border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+}
+
+.error-dismiss-button {
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 0.25rem;
 }
 
 /* Variable Groups */
@@ -557,6 +664,20 @@ body {
     transition: background 0.15s ease;
 }
 
+.variables-shell {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.variables-header {
+    align-items: flex-start;
+}
+
+.variables-actions {
+    flex-wrap: wrap;
+}
+
 .modern-variable-row:last-child {
     border-bottom: none;
 }
@@ -583,6 +704,14 @@ body {
     box-shadow: 0 0 0 3px var(--accent-light);
 }
 
+.modern-variable-row .var-key {
+    flex: 0.9;
+}
+
+.modern-variable-row .var-value {
+    flex: 1.1;
+}
+
 /* Snippet Library */
 .modern-snippet-library {
     max-height: 550px;
@@ -591,6 +720,17 @@ body {
     border-radius: var(--radius-lg);
     background: var(--bg-elevated);
     box-shadow: var(--shadow-sm);
+}
+
+.snippets-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.snippets-search {
+    width: 100%;
+    background: var(--bg-elevated);
 }
 
 .modern-snippet-item {
@@ -797,10 +937,48 @@ body {
     font-family: inherit;
 }
 
+.settings-field {
+    margin-bottom: 1rem;
+}
+
+.settings-label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+}
+
+.settings-toggle-group {
+    margin-bottom: 1rem;
+}
+
+.settings-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    cursor: pointer;
+    color: var(--text-primary);
+}
+
+.settings-toggle input {
+    accent-color: var(--accent);
+}
+
 .form-control:focus, .form-select:focus {
     outline: none;
     border-color: var(--aws-orange);
     box-shadow: 0 0 0 3px var(--accent-light);
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 /* Scrollbar */
@@ -820,14 +998,6 @@ body {
 
 ::-webkit-scrollbar-thumb:hover {
     background: var(--border-hover);
-}
-
-/* Divider */
-.vr {
-    width: 1px;
-    height: 28px;
-    background: var(--border-color);
-    margin: 0 0.5rem;
 }
 
 /* Utility Classes */
@@ -855,17 +1025,50 @@ body {
     .modern-toolbar {
         flex-direction: column;
         align-items: stretch;
+        top: 4.5rem;
+    }
+
+    .modern-toolbar .vr {
+        display: none;
+    }
+
+    .panel-header,
+    .panel-header-row,
+    .variables-header {
+        flex-direction: column;
+        align-items: stretch;
     }
     
     .modern-performance-stats {
         margin-left: 0;
         flex-wrap: wrap;
         width: 100%;
-        justify-content: center;
+        justify-content: flex-start;
+    }
+
+    .toolbar-action-group,
+    .toolbar-action-group-secondary {
+        width: 100%;
+    }
+
+    .toolbar-action-group .custom-btn,
+    .toolbar-action-group-secondary .custom-btn,
+    .toolbar-action-group-secondary .custom-dropdown-wrapper {
+        flex: 1;
     }
     
     .app-header h1 {
         font-size: 1.25rem;
+    }
+
+    .header-row {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .header-actions {
+        width: 100%;
+        justify-content: flex-end;
     }
     
     .modern-editor-container {
@@ -874,6 +1077,30 @@ body {
     
     .modern-result-panel {
         min-height: 300px;
+    }
+
+    .modern-variable-row {
+        flex-wrap: wrap;
+    }
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes loading-slide {
+    0% {
+        transform: translateX(-120%);
+    }
+
+    50% {
+        transform: translateX(90%);
+    }
+
+    100% {
+        transform: translateX(-120%);
     }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -606,6 +606,45 @@ body {
     min-height: 0;
 }
 
+.modern-result-panel.result-wrap {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.result-tools {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.result-chip {
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    background: var(--bg-elevated);
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    padding: 0.25rem 0.65rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+
+.result-chip.active {
+    color: var(--text-primary);
+    border-color: var(--accent);
+    background: var(--accent-light);
+}
+
+.result-font-size {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+}
+
 .result-panel-shell {
     display: flex;
     flex-direction: column;
@@ -776,6 +815,59 @@ body {
     align-items: center;
     justify-content: center;
     z-index: 9999;
+}
+
+.toast-stack {
+    position: fixed;
+    top: 5.75rem;
+    right: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 1200;
+    width: min(360px, calc(100vw - 2rem));
+}
+
+.toast-item {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.5rem;
+    border: 1px solid var(--border-color);
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-md);
+    padding: 0.65rem 0.75rem;
+}
+
+.toast-item-success {
+    border-left: 3px solid var(--success);
+}
+
+.toast-item-error {
+    border-left: 3px solid var(--error);
+}
+
+.toast-item-info {
+    border-left: 3px solid var(--primary);
+}
+
+.toast-message {
+    font-size: 0.8125rem;
+    line-height: 1.35;
+}
+
+.toast-dismiss {
+    border: none;
+    background: transparent;
+    color: inherit;
+    opacity: 0.7;
+    padding: 0;
+}
+
+.toast-dismiss:hover {
+    opacity: 1;
 }
 
 .modern-loading-content {
@@ -1081,6 +1173,11 @@ body {
 
     .modern-variable-row {
         flex-wrap: wrap;
+    }
+
+    .toast-stack {
+        top: auto;
+        bottom: 1rem;
     }
 }
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
-import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap-icons/font/bootstrap-icons.css'
 import './index.css'
 
@@ -10,4 +9,3 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <App />
   </React.StrictMode>,
 )
-

--- a/frontend/src/shims/fs.js
+++ b/frontend/src/shims/fs.js
@@ -1,0 +1,22 @@
+const unsupported = () => {
+  throw new Error('Filesystem access is not available in the browser runtime.');
+};
+
+export const readFileSync = unsupported;
+export const existsSync = () => false;
+export const statSync = () => ({
+  isDirectory: () => false,
+  isFile: () => false
+});
+
+export const promises = {
+  readFile: unsupported,
+  stat: unsupported
+};
+
+export default {
+  readFileSync,
+  existsSync,
+  statSync,
+  promises
+};

--- a/frontend/src/shims/path.js
+++ b/frontend/src/shims/path.js
@@ -1,0 +1,5 @@
+export const resolve = (...parts) => parts.filter(Boolean).join('/');
+
+export default {
+  resolve
+};

--- a/frontend/tests/e2e/smoke.spec.js
+++ b/frontend/tests/e2e/smoke.spec.js
@@ -1,16 +1,21 @@
 import { expect, test } from '@playwright/test';
 
-test('loads core workspace UI', async ({ page }) => {
+async function waitForWorkspace(page) {
   await page.goto('/');
-
   await expect(page.getByRole('heading', { name: 'VTL Emulator' })).toBeVisible();
+  await expect(page.locator('.modern-loading-overlay')).toHaveCount(0);
+}
+
+test('loads core workspace UI', async ({ page }) => {
+  await waitForWorkspace(page);
+
   await expect(page.getByRole('button', { name: 'Render' })).toBeVisible();
   await expect(page.getByRole('tab', { name: 'Template' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Output' })).toBeVisible();
 });
 
 test('opens and closes settings modal', async ({ page }) => {
-  await page.goto('/');
+  await waitForWorkspace(page);
 
   await page.getByRole('button', { name: 'Settings' }).click();
   await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
@@ -20,7 +25,7 @@ test('opens and closes settings modal', async ({ page }) => {
 });
 
 test('opens actions menu and navigates tabs', async ({ page }) => {
-  await page.goto('/');
+  await waitForWorkspace(page);
 
   await page.getByRole('button', { name: 'Actions' }).click();
   await expect(page.getByText('Import')).toBeVisible();
@@ -28,4 +33,110 @@ test('opens actions menu and navigates tabs', async ({ page }) => {
 
   await page.getByRole('tab', { name: 'Variables' }).click();
   await expect(page.getByText('Variable Groups')).toBeVisible();
+});
+
+test('renders template and shows output controls', async ({ page }) => {
+  await waitForWorkspace(page);
+
+  await page.getByRole('button', { name: 'Render' }).click();
+  await expect(page.locator('#result')).toContainText('Hello, World!');
+  await expect(page.locator('.modern-performance-stats')).toContainText('Render:');
+
+  await expect(page.getByRole('button', { name: 'Pretty JSON' })).toHaveClass(/active/);
+  await page.getByRole('button', { name: 'Pretty JSON' }).click();
+  await expect(page.getByRole('button', { name: 'Pretty JSON' })).not.toHaveClass(/active/);
+
+  await page.getByRole('button', { name: 'Wrap' }).click();
+  await expect(page.locator('#result')).toHaveClass(/result-wrap/);
+});
+
+test('supports debug flow and debug panel', async ({ page }) => {
+  await waitForWorkspace(page);
+
+  await page.getByRole('button', { name: 'Debug' }).click();
+  await page.getByRole('button', { name: 'Render' }).click();
+
+  await expect(page.getByText('Debug Information')).toBeVisible();
+  await expect(page.getByText('Rendering completed in')).toBeVisible();
+});
+
+test('can add and clear variables', async ({ page }) => {
+  await waitForWorkspace(page);
+
+  await page.getByRole('tab', { name: 'Variables' }).click();
+  await page.getByRole('button', { name: 'Add Variable' }).click();
+  await expect(page.locator('input[placeholder="Key"]')).toHaveCount(1);
+
+  await page.getByRole('button', { name: 'Clear All' }).click();
+  await page.getByRole('button', { name: 'Confirm Clear' }).click();
+  await expect(page.locator('input[placeholder="Key"]')).toHaveCount(0);
+});
+
+test('persists settings updates', async ({ page }) => {
+  await waitForWorkspace(page);
+
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await page.selectOption('select[name="fontSize"]', '18');
+  await page.getByRole('button', { name: 'Save Settings' }).click();
+
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await expect(page.locator('select[name="fontSize"]')).toHaveValue('18');
+  await page.getByRole('button', { name: 'Cancel' }).click();
+});
+
+test('exports configuration from actions menu', async ({ page }) => {
+  await waitForWorkspace(page);
+
+  await page.getByRole('button', { name: 'Actions' }).click();
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByText('Export').click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/^vtl-config-\d{4}-\d{2}-\d{2}\.json$/);
+  await expect(page.getByText('Configuration exported.')).toBeVisible();
+});
+
+test('opens and closes help modal from toolbar button', async ({ page }) => {
+  await waitForWorkspace(page);
+
+  await page.getByRole('button', { name: 'Help' }).click();
+  await expect(page.getByRole('heading', { name: 'VTL Emulator Help' })).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('heading', { name: 'VTL Emulator Help' })).toHaveCount(0);
+});
+
+test('opens help modal with keyboard shortcut', async ({ page }) => {
+  await waitForWorkspace(page);
+
+  await page.keyboard.press('Control+/');
+  await expect(page.getByRole('heading', { name: 'VTL Emulator Help' })).toBeVisible();
+});
+
+test('toggles auto render button state', async ({ page }) => {
+  await waitForWorkspace(page);
+
+  const autoButton = page.getByRole('button', { name: 'Auto' });
+  await autoButton.click();
+  await expect(page.getByRole('button', { name: 'Auto ON' })).toBeVisible();
+  await page.getByRole('button', { name: 'Auto ON' }).click();
+  await expect(page.getByRole('button', { name: 'Auto' })).toBeVisible();
+});
+
+test('inserts snippet and returns to template tab', async ({ page }) => {
+  await waitForWorkspace(page);
+
+  await page.getByRole('tab', { name: 'Snippets' }).click();
+  await expect(page.locator('.modern-snippet-item').first()).toBeVisible();
+  await page.locator('.modern-snippet-item').first().click();
+  await expect(page.getByRole('tab', { name: 'Template', selected: true })).toBeVisible();
+});
+
+test('clears result and shows toast', async ({ page }) => {
+  await waitForWorkspace(page);
+
+  await page.getByRole('button', { name: 'Render' }).click();
+  await expect(page.locator('#result')).toContainText('Hello, World!');
+
+  await page.locator('button[title="Clear"]').click();
+  await expect(page.locator('#result')).toContainText('Click "Render" to see the VTL output here...');
+  await expect(page.getByText('Output cleared.')).toBeVisible();
 });

--- a/frontend/tests/e2e/smoke.spec.js
+++ b/frontend/tests/e2e/smoke.spec.js
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+
+test('loads core workspace UI', async ({ page }) => {
+  await page.goto('/');
+
+  await expect(page.getByRole('heading', { name: 'VTL Emulator' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Render' })).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Template' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Output' })).toBeVisible();
+});
+
+test('opens and closes settings modal', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Cancel' }).click();
+  await expect(page.getByRole('heading', { name: 'Settings' })).toHaveCount(0);
+});
+
+test('opens actions menu and navigates tabs', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Actions' }).click();
+  await expect(page.getByText('Import')).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  await page.getByRole('tab', { name: 'Variables' }).click();
+  await expect(page.getByText('Variable Groups')).toBeVisible();
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,9 +1,26 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
+
+const velocitsBrowserEntry = fileURLToPath(
+  new URL('./node_modules/velocits/dist-browser/browser.js', import.meta.url)
+)
+const fsShim = fileURLToPath(new URL('./src/shims/fs.js', import.meta.url))
+const pathShim = fileURLToPath(new URL('./src/shims/path.js', import.meta.url))
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      velocits: velocitsBrowserEntry,
+      fs: fsShim,
+      'node:fs': fsShim,
+      'node:fs/promises': fsShim,
+      path: pathShim,
+      'node:path': pathShim
+    }
+  },
   base: '/',
   build: {
     outDir: 'dist',
@@ -17,4 +34,3 @@ export default defineConfig({
     include: ['apigw-vtl-emulator']
   }
 })
-


### PR DESCRIPTION
## Summary
- update the frontend to consume `apigw-vtl-emulator@^1.2.0`
- remove the engine selector from the toolbar so the UI always uses the built-in Velocits-backed engine
- refresh the main README and frontend docs to match the single-engine frontend flow

## Validation
- npm run build (`frontend`)

## Notes
- the frontend still builds successfully, but Vite continues to warn about `fs` and `path` browser externalization from `velocits`; this is the separate packaging issue we already identified