### PR TITLE
feat(java): publish apigw-vtl-emulator to Maven Central

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -31,6 +31,13 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
@@ -48,6 +55,10 @@ jobs:
 
       - name: Test
         run: npm test
+
+      - name: Test Java emulator
+        working-directory: emulator/java
+        run: mvn clean test
 
       - name: Release
         id: semantic_release
@@ -95,3 +106,59 @@ jobs:
           unset NPM_TOKEN
           unset NPM_CONFIG_USERCONFIG
           npm publish --provenance
+
+  publish-maven:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://central.sonatype.com/
+    defaults:
+      run:
+        working-directory: emulator/java
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Import GPG key
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo "$GPG_PRIVATE_KEY" | base64 -d | gpg --batch --import
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          gpgconf --kill gpg-agent
+          gpgconf --launch gpg-agent
+
+      - name: Configure Maven settings
+        env:
+          CENTRAL_PORTAL_USERNAME: ${{ secrets.CENTRAL_PORTAL_USERNAME }}
+          CENTRAL_PORTAL_TOKEN: ${{ secrets.CENTRAL_PORTAL_TOKEN }}
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<EOF
+          <settings>
+            <servers>
+              <server>
+                <id>central</id>
+                <username>${CENTRAL_PORTAL_USERNAME}</username>
+                <password>${CENTRAL_PORTAL_TOKEN}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+
+      - name: Publish to Maven Central
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: mvn -Prelease clean deploy -DskipTests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Verify library artifacts
         run: |
-          test -f target/apigw-vtl-emulator-*.jar
+          main_jar=$(ls target/apigw-vtl-emulator-*.jar | grep -Ev 'sources|javadoc|standalone' | wc -l | tr -d ' ')
+          test "$main_jar" -eq 1
           test -f target/apigw-vtl-emulator-*-sources.jar
           test -f target/apigw-vtl-emulator-*-javadoc.jar

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,3 +88,9 @@ jobs:
 
       - name: Build JAR
         run: mvn clean package -DskipTests
+
+      - name: Verify library artifacts
+        run: |
+          test -f target/apigw-vtl-emulator-*.jar
+          test -f target/apigw-vtl-emulator-*-sources.jar
+          test -f target/apigw-vtl-emulator-*-javadoc.jar

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ replay_pid*
 
 # Maven
 target/
-!emulator/target/vtl-processor.jar
+!emulator/java/target/apigw-vtl-emulator-*-standalone.jar
 
 # Generated assets (built by CI)
 assets/
@@ -248,9 +248,8 @@ coverage/
 *.sqlite3
 
 # Application specific
-# Keep the compiled JAR for the web application to use
-!emulator/target/vtl-processor.jar
-!frontend/public/vtl-processor.jar
+# Optional standalone fat JAR (mvn package -Pstandalone)
+!emulator/java/target/apigw-vtl-emulator-*-standalone.jar
 
 # AWS CDK
 # CDK output directory contains account IDs, IAM roles, and other sensitive information

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,8 @@ Thanks for contributing. This repository has two main parts:
 | Folder | Description |
 | --- | --- |
 | `frontend/` | React 19 + Vite UI for template editing and rendering |
-| `emulator/typescript/` | Published TypeScript package (`apigw-vtl-emulator`) |
-| `emulator/java/` | Legacy Java implementation and compatibility tests |
+| `emulator/typescript/` | Published TypeScript package (`apigw-vtl-emulator` on npm) |
+| `emulator/java/` | Published Java library (`dev.vtlemulator:apigw-vtl-emulator` on Maven Central) |
 
 ## Prerequisites
 
@@ -60,7 +60,20 @@ mvn clean test
 
 - Include tests with all behavior changes
 - Keep AWS API Gateway compatibility as the baseline
-- Favor deterministic, browser-compatible behavior in the TypeScript package
+- Update both Java and TypeScript implementations when changing engine behavior
+
+## Maven Central Publishing (maintainers)
+
+The Java library is published to Maven Central via the `publish-maven` job in `.github/workflows/semantic-release.yml`. Required GitHub repository secrets in the `production` environment:
+
+| Secret | Description |
+| --- | --- |
+| `CENTRAL_PORTAL_USERNAME` | Sonatype Central Portal token username |
+| `CENTRAL_PORTAL_TOKEN` | Sonatype Central Portal token password |
+| `GPG_PRIVATE_KEY` | Base64-encoded GPG private key for artifact signing |
+| `GPG_PASSPHRASE` | Passphrase for the GPG key |
+
+Generate a Central Portal token at [central.sonatype.com](https://central.sonatype.com/). Publish the GPG public key to [keys.openpgp.org](https://keys.openpgp.org/) before the first release.
 
 ## CI Expectations
 

--- a/README.md
+++ b/README.md
@@ -30,15 +30,32 @@ workflows.
 
 ## 🚀 Engine
 
-The VTL Emulator uses a single built-in Velocits TypeScript engine for VTL processing in the browser:
+The VTL Emulator ships two published engine implementations:
 
-- **Type**: Pure TypeScript VTL processor
-- **Performance**: Fast
-- **Size**: Medium
-- **Features**: AWS API Gateway helpers, JSONPath support, browser-native execution
-- **Best for**: Fast development and testing without extra runtime assets
+| Platform | Package | Best for |
+|----------|---------|----------|
+| **TypeScript** (browser UI) | [`apigw-vtl-emulator`](https://www.npmjs.com/package/apigw-vtl-emulator) on npm | Browser and Node.js |
+| **Java** | `dev.vtlemulator:apigw-vtl-emulator` on Maven Central | JVM backends and integration tests |
 
-There is no runtime engine selector in the UI anymore; the frontend always uses the Velocits-powered emulator package.
+The frontend uses the TypeScript engine. Both implementations share the same VTL compatibility test suite.
+
+### TypeScript (npm)
+
+```bash
+npm install apigw-vtl-emulator
+```
+
+### Java (Maven)
+
+```xml
+<dependency>
+  <groupId>dev.vtlemulator</groupId>
+  <artifactId>apigw-vtl-emulator</artifactId>
+  <version>1.2.0</version>
+</dependency>
+```
+
+See [`emulator/README.md`](./emulator/README.md) for engine development and usage details.
 
 ---
 
@@ -50,7 +67,7 @@ This repository contains:
 |--------------------|--------------------------------------------------|
 | `/index.html`      | Redirect page to the new website                |
 | `/frontend/`       | React-based frontend application                 |
-| `/emulator/`       | The standalone VTL engine used by the UI and NPM |
+| `/emulator/`       | VTL engines published to npm and Maven Central     |
 | `/img.png`         | Screenshot used in documentation                 |
 | `/CONTRIBUTING.md` | Contribution guide for engine and UI development |
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ npm install apigw-vtl-emulator
 <dependency>
   <groupId>dev.vtlemulator</groupId>
   <artifactId>apigw-vtl-emulator</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
 </dependency>
 ```
 

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -1,15 +1,15 @@
 # VTL Processor Implementations
 
-This directory contains two implementations of AWS API Gateway VTL (Velocity Template Language) processor:
+This directory contains two published implementations of AWS API Gateway VTL (Velocity Template Language) processor:
 
-1. **Java Implementation** - The original legacy processor
-2. **TypeScript Implementation** - A new velocits-based processor
+1. **Java Implementation** — JVM library on Maven Central (`dev.vtlemulator:apigw-vtl-emulator`)
+2. **TypeScript Implementation** — npm package (`apigw-vtl-emulator`)
 
 ## Directory Structure
 
 ```
 emulator/
-├── java/                           # Java implementation
+├── java/                           # Java implementation (Maven)
 │   ├── src/
 │   │   ├── main/java/dev/vtlemulator/engine/
 │   │   │   ├── VTLProcessor.java
@@ -19,9 +19,8 @@ emulator/
 │   │   └── test/
 │   │       ├── java/               # Unit tests
 │   │       └── resources/vtl-test-cases/  # File-based test cases
-│   ├── target/
-│   │   └── vtl-processor.jar
-│   └── pom.xml
+│   ├── pom.xml
+│   └── README.md
 │
 └── typescript/                     # TypeScript implementation (Velocits)
     ├── src/
@@ -50,6 +49,18 @@ Both implementations provide complete AWS API Gateway VTL compatibility, includi
 
 ## Java Implementation
 
+### Installation
+
+```xml
+<dependency>
+  <groupId>dev.vtlemulator</groupId>
+  <artifactId>apigw-vtl-emulator</artifactId>
+  <version>1.2.0</version>
+</dependency>
+```
+
+See [java/README.md](java/README.md) for full documentation.
+
 ### Prerequisites
 
 - Java 17 or higher
@@ -70,16 +81,22 @@ mvn test
 
 ### Usage
 
-#### Java API
-
 ```java
 import dev.vtlemulator.engine.VTLProcessor;
 
 VTLProcessor processor = new VTLProcessor();
-String result = processor.process(template, input, context);
+String result = processor.process(template, inputBody, contextJson);
 ```
 
 ## TypeScript Implementation
+
+### Installation
+
+```bash
+npm install apigw-vtl-emulator
+```
+
+See [typescript/README.md](typescript/README.md) for full documentation.
 
 ### Prerequisites
 
@@ -102,36 +119,21 @@ npm test
 
 ### Usage
 
-#### TypeScript/JavaScript API
-
 ```typescript
-import { VTLProcessor } from '@apigw-vtl-emulator/typescript';
+import { VTLProcessor } from 'apigw-vtl-emulator';
 
 const processor = new VTLProcessor();
 const result = processor.process(template, inputBody, contextJson);
 ```
 
-#### Browser Usage
-
-The TypeScript implementation can be imported directly in the frontend via Vite:
-
-```javascript
-import { VTLProcessor } from '@apigw-vtl-emulator/typescript';
-
-const processor = new VTLProcessor();
-const result = processor.process(template, body, context);
-```
-
 ## Comparison
 
-| Feature | Java (Legacy) | TypeScript (Velocits) |
-|---------|----------------|----------------------|
-| **Performance** | Medium (WebAssembly overhead) | Fast (native JavaScript) |
-| **Bundle Size** | Large (~10MB) | Medium (~500KB) |
-| **AWS Compatibility** | ✅ Full | ✅ Full |
-| **Browser Support** | ✅ All modern browsers | ✅ All modern browsers |
-| **Load Time** | ~2-5 seconds | ~100ms |
-| **Recommended** | Legacy support | ⚡ **Yes** |
+| Feature | Java | TypeScript (Velocits) |
+|---------|------|----------------------|
+| **Runtime** | JVM (Java 17+) | Node.js / browser |
+| **Registry** | Maven Central | npm |
+| **AWS Compatibility** | Full | Full |
+| **Best for** | JVM backends, integration tests | Browser UI, Node.js apps |
 
 ## Test Suite
 
@@ -192,7 +194,7 @@ cd typescript && npm test
 
 ## Frontend Integration
 
-The frontend uses the Velocits TypeScript implementation.
+The frontend uses the TypeScript implementation via the `apigw-vtl-emulator` npm package.
 
 ## Development
 
@@ -209,8 +211,8 @@ Both implementations must pass the same test suite to ensure AWS API Gateway com
 
 1. Update both implementations
 2. Run full test suite
-3. Verify frontend works with both engines
+3. Verify frontend works with the TypeScript engine
 
 ## License
 
-This project is part of the VTL Emulator suite and follows the same licensing terms.
+MIT — see LICENSE files in each implementation directory.

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -55,7 +55,7 @@ Both implementations provide complete AWS API Gateway VTL compatibility, includi
 <dependency>
   <groupId>dev.vtlemulator</groupId>
   <artifactId>apigw-vtl-emulator</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
 </dependency>
 ```
 

--- a/emulator/java/LICENSE
+++ b/emulator/java/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Christian G. Faraone
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/emulator/java/README.md
+++ b/emulator/java/README.md
@@ -1,0 +1,100 @@
+# apigw-vtl-emulator (Java)
+
+> Java implementation of AWS API Gateway VTL (Velocity Template Language) Emulator
+
+A complete, fully-tested implementation of AWS API Gateway's VTL processor for JVM applications. Built on [Apache Velocity](https://velocity.apache.org/) and Jackson.
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+## Features
+
+- **Complete AWS API Gateway VTL support** — `$input.*`, `$context.*`, `$util.*`, and VTL directives
+- **Java 17+** — runs on modern JVMs
+- **Fully tested** — shares the same VTL test suite as the TypeScript implementation
+
+## Installation
+
+### Maven
+
+```xml
+<dependency>
+  <groupId>dev.vtlemulator</groupId>
+  <artifactId>apigw-vtl-emulator</artifactId>
+  <version>1.2.0</version>
+</dependency>
+```
+
+### Gradle
+
+```kotlin
+implementation("dev.vtlemulator:apigw-vtl-emulator:1.2.0")
+```
+
+## Quick Start
+
+```java
+import dev.vtlemulator.engine.VTLProcessor;
+
+VTLProcessor processor = new VTLProcessor();
+
+String template = """
+    {
+      "message": $input.json('$.message'),
+      "requestId": "$context.requestId",
+      "stage": "$context.stage"
+    }
+    """;
+
+String inputBody = "{\"message\":\"Hello, World!\"}";
+
+String context = """
+    {
+      "requestId": "test-123",
+      "stage": "prod",
+      "httpMethod": "POST"
+    }
+    """;
+
+String result = processor.process(template, inputBody, context);
+// {"message":"Hello, World!","requestId":"test-123","stage":"prod"}
+```
+
+## API
+
+```java
+VTLProcessor processor = new VTLProcessor();
+
+// template + context JSON only (empty input body)
+processor.process(template, contextJson);
+
+// template + input body + context JSON
+processor.process(template, inputBody, contextJson);
+```
+
+## Building from Source
+
+```bash
+cd emulator/java
+mvn clean test
+mvn clean package
+```
+
+Optional fat JAR with bundled dependencies:
+
+```bash
+mvn clean package -Pstandalone
+# target/apigw-vtl-emulator-1.2.0-standalone.jar
+```
+
+## Related Packages
+
+| Platform | Coordinates |
+|----------|-------------|
+| npm | [`apigw-vtl-emulator`](https://www.npmjs.com/package/apigw-vtl-emulator) |
+| Maven | `dev.vtlemulator:apigw-vtl-emulator` |
+
+Both implementations share the same VTL compatibility test suite.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/emulator/java/README.md
+++ b/emulator/java/README.md
@@ -20,14 +20,14 @@ A complete, fully-tested implementation of AWS API Gateway's VTL processor for J
 <dependency>
   <groupId>dev.vtlemulator</groupId>
   <artifactId>apigw-vtl-emulator</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```kotlin
-implementation("dev.vtlemulator:apigw-vtl-emulator:1.2.0")
+implementation("dev.vtlemulator:apigw-vtl-emulator:1.3.0")
 ```
 
 ## Quick Start
@@ -83,7 +83,7 @@ Optional fat JAR with bundled dependencies:
 
 ```bash
 mvn clean package -Pstandalone
-# target/apigw-vtl-emulator-1.2.0-standalone.jar
+# target/apigw-vtl-emulator-1.3.0-standalone.jar
 ```
 
 ## Related Packages

--- a/emulator/java/pom.xml
+++ b/emulator/java/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>dev.vtlemulator</groupId>
     <artifactId>apigw-vtl-emulator</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
 
     <name>AWS API Gateway VTL Emulator</name>
@@ -40,48 +40,66 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
+        <velocity.version>2.4.1</velocity.version>
+        <jackson.version>2.22.0</jackson.version>
+        <junit.version>4.13.2</junit.version>
+        <aws-cdk.version>2.260.0</aws-cdk.version>
+        <constructs.version>10.6.0</constructs.version>
+        <aws-sdk.version>2.46.17</aws-sdk.version>
+        <okhttp.version>4.12.0</okhttp.version>
+        <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>software.amazon.awssdk</groupId>
+                <artifactId>bom</artifactId>
+                <version>${aws-sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-engine-core</artifactId>
-            <version>2.3</version>
+            <version>${velocity.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
-            <version>2.120.0</version>
+            <version>${aws-cdk.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>software.constructs</groupId>
             <artifactId>constructs</artifactId>
-            <version>10.3.0</version>
+            <version>${constructs.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apigateway</artifactId>
-            <version>2.20.162</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.12.0</version>
+            <version>${okhttp.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -91,7 +109,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.14.0</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
@@ -138,7 +156,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-shade-plugin</artifactId>
-                        <version>3.2.4</version>
+                        <version>3.6.0</version>
                         <executions>
                             <execution>
                                 <phase>package</phase>

--- a/emulator/java/pom.xml
+++ b/emulator/java/pom.xml
@@ -1,19 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
          http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>dev.vtlemulator</groupId>
-    <artifactId>vtl-engine</artifactId>
-    <version>1.0.0</version>
+    <artifactId>apigw-vtl-emulator</artifactId>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
+
+    <name>AWS API Gateway VTL Emulator</name>
+    <description>Java implementation of AWS API Gateway VTL (Velocity Template Language) Emulator</description>
+    <url>https://github.com/fearlessfara/apigw-vtl-emulator</url>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Christian Gennaro Faraone</name>
+            <email>christiangenn99@gmail.com</email>
+            <url>https://github.com/fearlessfara</url>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/fearlessfara/apigw-vtl-emulator.git</connection>
+        <developerConnection>scm:git:ssh://github.com/fearlessfara/apigw-vtl-emulator.git</developerConnection>
+        <url>https://github.com/fearlessfara/apigw-vtl-emulator/tree/main/emulator/java</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <central-publishing-maven-plugin.version>0.7.0</central-publishing-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -33,7 +60,6 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
-        <!-- AWS CDK for integration testing -->
         <dependency>
             <groupId>software.amazon.awscdk</groupId>
             <artifactId>aws-cdk-lib</artifactId>
@@ -46,14 +72,12 @@
             <version>10.3.0</version>
             <scope>test</scope>
         </dependency>
-        <!-- AWS SDK for invoking API Gateway -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>apigateway</artifactId>
             <version>2.20.162</version>
             <scope>test</scope>
         </dependency>
-        <!-- HTTP client for testing -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
@@ -61,6 +85,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
             <plugin>
@@ -74,48 +99,122 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>attach-sources</id>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>jar-no-fork</goal>
                         </goals>
-                        <configuration>
-                            <finalName>vtl-processor</finalName>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                            <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>META-INF/*.SF</exclude>
-                                        <exclude>META-INF/*.DSA</exclude>
-                                        <exclude>META-INF/*.RSA</exclude>
-                                        <exclude>META-INF/MANIFEST.MF</exclude>
-                                        <exclude>META-INF/LICENSE</exclude>
-                                        <exclude>META-INF/NOTICE</exclude>
-                                        <exclude>META-INF/LICENSE.txt</exclude>
-                                        <exclude>META-INF/NOTICE.txt</exclude>
-                                        <exclude>META-INF/versions/**</exclude>
-                                        <exclude>module-info.class</exclude>
-                                    </excludes>
-                                </filter>
-                            </filters>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>dev.vtlemulator.engine.VTLProcessor</mainClass>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
-                            </transformers>
-                            <minimizeJar>false</minimizeJar>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.11.2</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <doclint>none</doclint>
+                    <quiet>true</quiet>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-</project> 
+
+    <profiles>
+        <profile>
+            <id>standalone</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-shade-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>shade</goal>
+                                </goals>
+                                <configuration>
+                                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                                    <shadedClassifierName>standalone</shadedClassifierName>
+                                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                                    <filters>
+                                        <filter>
+                                            <artifact>*:*</artifact>
+                                            <excludes>
+                                                <exclude>META-INF/*.SF</exclude>
+                                                <exclude>META-INF/*.DSA</exclude>
+                                                <exclude>META-INF/*.RSA</exclude>
+                                                <exclude>META-INF/MANIFEST.MF</exclude>
+                                                <exclude>META-INF/LICENSE</exclude>
+                                                <exclude>META-INF/NOTICE</exclude>
+                                                <exclude>META-INF/LICENSE.txt</exclude>
+                                                <exclude>META-INF/NOTICE.txt</exclude>
+                                                <exclude>META-INF/versions/**</exclude>
+                                                <exclude>module-info.class</exclude>
+                                            </excludes>
+                                        </filter>
+                                    </filters>
+                                    <transformers>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
+                                    </transformers>
+                                    <minimizeJar>false</minimizeJar>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.7</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central-publishing-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/emulator/typescript/.releaserc.json
+++ b/emulator/typescript/.releaserc.json
@@ -6,14 +6,14 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "npm version ${nextRelease.version} --no-git-tag-version --allow-same-version"
+        "prepareCmd": "npm version ${nextRelease.version} --no-git-tag-version --allow-same-version && mvn -f ../java versions:set -DnewVersion=${nextRelease.version} -DgenerateBackupPoms=false"
       }
     ],
     "@semantic-release/github",
     [
       "@semantic-release/git",
       {
-        "assets": ["package.json", "package-lock.json"],
+        "assets": ["package.json", "package-lock.json", "../java/pom.xml"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ]

--- a/emulator/typescript/package-lock.json
+++ b/emulator/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apigw-vtl-emulator",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apigw-vtl-emulator",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "velocits": "^1.2.1"

--- a/emulator/typescript/package.json
+++ b/emulator/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apigw-vtl-emulator",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "TypeScript/JavaScript implementation of AWS API Gateway VTL Emulator - works in Node.js and browsers",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Refactor `emulator/java` into a Maven Central library (`dev.vtlemulator:apigw-vtl-emulator` v1.2.0) with sources, javadoc, and optional standalone fat JAR profile
- Add `publish-maven` CI job alongside npm publishing, with unified semver via semantic-release
- Document Java installation and maintainer secrets in README, emulator docs, and CONTRIBUTING

## Test plan
- [x] `mvn clean verify` passes locally in `emulator/java`
- [x] Library JAR, sources JAR, and javadoc JAR are produced
- [x] Sonatype namespace `dev.vtlemulator` verified
- [x] GitHub `production` secrets configured (Central Portal + GPG)
- [ ] CI passes on PR
- [ ] After merge: approve `production` environment when semantic-release runs — both npm and Maven should publish

**Note:** Merging this PR with a `feat:` commit will trigger semantic-release. The POM is aligned at `1.2.0` with npm today; the release job will bump both packages to the next semver version before publishing.


Made with [Cursor](https://cursor.com)