### PR TITLE
fix(ci): release without pushing version commits to protected main

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -94,6 +94,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Set release version
+        run: npm version ${{ needs.release.outputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Build
         run: npm run build
@@ -121,7 +124,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
-          ref: main
+          ref: ${{ github.sha }}
 
       - name: Set up Java
         uses: actions/setup-java@v5
@@ -129,6 +132,9 @@ jobs:
           distribution: temurin
           java-version: '21'
           cache: maven
+
+      - name: Set release version
+        run: mvn versions:set -DnewVersion=${{ needs.release.outputs.version }} -DgenerateBackupPoms=false
 
       - name: Import GPG key
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,8 @@ The Java library is published to Maven Central via the `publish-maven` job in `.
 
 Generate a Central Portal token at [central.sonatype.com](https://central.sonatype.com/). Publish the GPG public key to [keys.openpgp.org](https://keys.openpgp.org/) before the first release.
 
+Release tags and registry versions are managed by semantic-release. Version files on `main` (`package.json`, `pom.xml`) are bumped in publish jobs at release time and are not pushed back to `main` automatically because branch protection requires pull requests. After a release, open a small follow-up PR to sync those version files if they drift.
+
 ## CI Expectations
 
 PRs to `main` should pass:

--- a/emulator/typescript/.releaserc.json
+++ b/emulator/typescript/.releaserc.json
@@ -9,13 +9,6 @@
         "prepareCmd": "npm version ${nextRelease.version} --no-git-tag-version --allow-same-version && mvn -f ../java versions:set -DnewVersion=${nextRelease.version} -DgenerateBackupPoms=false"
       }
     ],
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "package-lock.json", "../java/pom.xml"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary
- Remove `@semantic-release/git` — semantic-release can no longer push `chore(release)` commits to protected `main`
- Publish jobs checkout the triggering commit and apply the release version before npm/Maven deploy
- Document version file sync in CONTRIBUTING

Fixes release job failure: `GH006: Protected branch update failed for refs/heads/main`

## Test plan
- [ ] Merge PR
- [ ] Approve `production` environment when semantic-release publishes **1.3.1**
- [ ] Confirm npm and Maven Central publish succeed


Made with [Cursor](https://cursor.com)