### PR TITLE
fix(ci): use MAVEN_GPG_PASSPHRASE for Maven signing

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -170,5 +170,5 @@ jobs:
 
       - name: Publish to Maven Central
         env:
-          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: mvn -Prelease clean deploy -DskipTests -Dgpg.passphrase="$GPG_PASSPHRASE"
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: mvn -Prelease clean deploy -DskipTests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ The Java library is published to Maven Central via the `publish-maven` job in `.
 | `CENTRAL_PORTAL_USERNAME` | Sonatype Central Portal token username |
 | `CENTRAL_PORTAL_TOKEN` | Sonatype Central Portal token password |
 | `GPG_PRIVATE_KEY` | Base64-encoded GPG private key for artifact signing |
-| `GPG_PASSPHRASE` | Passphrase for the GPG key |
+| `GPG_PASSPHRASE` | Passphrase for the GPG key (exported as `MAVEN_GPG_PASSPHRASE` during Maven deploy) |
 
 Generate a Central Portal token at [central.sonatype.com](https://central.sonatype.com/). Publish the GPG public key to [keys.openpgp.org](https://keys.openpgp.org/) before the first release.
 


### PR DESCRIPTION
## Summary
- Stop passing `-Dgpg.passphrase` to Maven (deprecated; may leak in logs)
- Use `MAVEN_GPG_PASSPHRASE` env var instead, mapped from the existing `GPG_PASSPHRASE` secret

## Test plan
- [ ] Merge PR
- [ ] Next Maven publish run shows no gpg.passphrase deprecation warnings


Made with [Cursor](https://cursor.com)